### PR TITLE
perf(explore,community): reduce duplicate fetches and paint cost\n\n-…

### DIFF
--- a/src/app/[slug]/ClientPage.tsx
+++ b/src/app/[slug]/ClientPage.tsx
@@ -128,6 +128,8 @@ export default function ClientCommunityPage({ initial }: { initial?: any }) {
   // 사용자 로그인/변경 시 membership을 최신 응답으로 동기화
   useEffect(() => {
     if (!community?.id || !user?.id) return
+    // SSR 초기 렌더에서 membership을 이미 전달받았다면 즉시 재조회 생략
+    if (initial?.membership != null) return
     let cancelled = false
     ;(async () => {
       try {
@@ -142,7 +144,7 @@ export default function ClientCommunityPage({ initial }: { initial?: any }) {
       } catch {}
     })()
     return () => { cancelled = true }
-  }, [user?.id, community?.id, slug])
+  }, [user?.id, community?.id, slug, initial?.membership])
 
   // checkMembership 제거 (API에서 제공)
 

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -1,7 +1,8 @@
 import { fetchExploreCommunities } from '@/lib/dashboard'
 import ClientExplorePage from '@/app/explore/ClientExplorePage'
 
-export const revalidate = 0
+// 둘러보기 목록은 60초 ISR로 서버 캐시를 활용
+export const revalidate = 60
 
 export default async function ExplorePage() {
   const initial = await fetchExploreCommunities({})


### PR DESCRIPTION
… [slug]/ClientPage: skip membership refetch when SSR initial includes it\n- explore/page: enable 60s ISR for initial list fetch\n- explore/ClientExplorePage: lazy-load AnimatedBackground on idle to cut initial paint\n\nNo logic change for data shape; conservative perf tuning.