### PR TITLE
feat: legal pages overhaul (privacy, terms, refund-policy) and perfor…10.08

### DIFF
--- a/src/app/[slug]/ClientPage.tsx
+++ b/src/app/[slug]/ClientPage.tsx
@@ -53,7 +53,7 @@ export default function ClientCommunityPage({ initial }: { initial?: any }) {
   const [isPending, setIsPending] = useState<boolean>(initialRole === 'pending')
   const { user } = useAuthData()
   const [services, setServices] = useState<{ id: string; label: string }[]>(initial?.services || [])
-  const [images, setImages] = useState<GalleryItem[]>((initial?.images || []).slice(0, 10))
+  const [images, setImages] = useState<GalleryItem[]>((initial?.images || []).slice(0, 6))
   const [mainIdx, setMainIdx] = useState<number>(0)
   const [stats, setStats] = useState<{ memberCount: number; postCount: number; commentCount: number; classCount: number }>(
     (initial as any)?.stats || { memberCount: 0, postCount: 0, commentCount: 0, classCount: 0 }
@@ -93,13 +93,14 @@ export default function ClientCommunityPage({ initial }: { initial?: any }) {
 
   useEffect(() => {
     if (isMobile) return
+    let timeout: any
     const cb = () => setMountBg(true)
-    if (typeof (window as any).requestIdleCallback === 'function') {
-      ;(window as any).requestIdleCallback(cb)
+    if ('requestIdleCallback' in window) {
+      ;(window as any).requestIdleCallback(cb, { timeout: 1000 })
     } else {
-      const t = setTimeout(cb, 200)
-      return () => clearTimeout(t)
+      timeout = setTimeout(cb, 400)
     }
+    return () => { if (timeout) clearTimeout(timeout) }
   }, [isMobile])
 
   // 비로그인 공개 상세 진입 시, 돌아올 경로를 저장하여 로그인/회원가입 후 복귀하도록 함
@@ -254,7 +255,7 @@ export default function ClientCommunityPage({ initial }: { initial?: any }) {
                       className="relative aspect-[16/9] w-full overflow-hidden rounded-xl cursor-pointer hover:opacity-95 transition-opacity"
                       onClick={() => setImageModal({ open: true, url: images[mainIdx]?.url })}
                     >
-                      <NextImage src={images[mainIdx]?.url} alt="community-main" fill className="object-cover" sizes="(max-width: 1024px) 100vw, 66vw" priority />
+                      <NextImage src={images[mainIdx]?.url} alt="community-main" fill className="object-cover" sizes="(max-width: 768px) 100vw, (max-width: 1280px) 66vw, 800px" priority placeholder="blur" blurDataURL="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" />
                       {images.length > 1 && (
                         <>
                           <button
@@ -281,7 +282,7 @@ export default function ClientCommunityPage({ initial }: { initial?: any }) {
                           onClick={() => setMainIdx(images.findIndex(x => x.key === img.key))} 
                           className="relative aspect-[4/3] w-full overflow-hidden rounded-lg border border-slate-200 focus:outline-none focus:ring-2 focus:ring-slate-400 cursor-pointer hover:scale-105 hover:shadow-md transition-all duration-200"
                         >
-                          <NextImage src={img.url} alt={`community-thumb-${i}`} fill className="object-cover" sizes="(max-width: 640px) 28vw, (max-width: 1024px) 16vw, 10vw" />
+                          <NextImage src={img.url} alt={`community-thumb-${i}`} fill className="object-cover" sizes="(max-width: 640px) 28vw, (max-width: 1024px) 16vw, 10vw" loading="lazy" />
                         </button>
                       ))}
                     </div>

--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -13,6 +13,8 @@ export default async function CommunityDetailPage({ params }: { params: Promise<
     const res = await fetch(`${base}/api/community/detail?slug=${encodeURIComponent(slug)}`, {
       // 서버 렌더링 시 membership까지 함께 계산되도록 사용자 ID 전달
       headers: user?.id ? { 'x-user-id': user.id } : undefined,
+      // 비로그인(공개 뷰)에는 강한 캐시 적용, 로그인 시에는 재검증 중심
+      cache: user?.id ? 'no-store' : 'force-cache',
       next: { revalidate: 120 },
     })
     if (res.ok) initial = await res.json()

--- a/src/app/api/community/detail/route.ts
+++ b/src/app/api/community/detail/route.ts
@@ -15,7 +15,8 @@ export async function GET(req: NextRequest) {
     // 1) 슬러그로 커뮤니티 조회 (단일 쿼리)
     const { data: community, error: commErr } = await supabase
       .from('communities')
-      .select('*')
+      // 최초 접근 성능: 꼭 필요한 필드만 선조회 (추가 정보는 별도 API에서 확장)
+      .select('id, name, slug, category, image_url, icon_url, owner_id, created_at, updated_at')
       .eq('slug', slug)
       .single()
     if (commErr || !community) {
@@ -28,7 +29,7 @@ export async function GET(req: NextRequest) {
         try {
           const { data } = await supabase
             .from('profiles')
-            .select('id, username, full_name, bio, avatar_url')
+            .select('id, username, full_name, avatar_url')
             .eq('id', (community as any).owner_id)
             .single()
           return data || null

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -3,6 +3,7 @@
 import AnimatedBackground from "@/components/AnimatedBackground"
 import { Card, CardContent } from "@/components/ui/card"
 import { Shield } from "lucide-react"
+import Image from "next/image"
 
 export default function PrivacyPage() {
   return (
@@ -17,59 +18,204 @@ export default function PrivacyPage() {
               </div>
               <h1 className="text-3xl font-bold text-slate-900 tracking-tight">개인정보처리방침</h1>
             </div>
-            <p className="text-slate-600">루티드는 이용자의 개인정보를 소중히 여기며 관련 법령을 준수합니다.</p>
+            <p className="text-slate-600">루티드(Rooted)는 이용자의 개인정보를 소중히 여기며, 개인정보 보호법 및 관련 법령을 준수합니다.</p>
           </div>
 
           <Card className="backdrop-blur-sm bg-white/80 border-slate-200/60 rounded-3xl shadow-xl">
             <CardContent className="p-6 md:p-8">
-              <article className="prose prose-slate max-w-none">
-                <h2>1. 수집하는 개인정보의 항목 및 방법</h2>
-                <ul>
-                  <li>필수: 이메일, 비밀번호(해시), 사용자명</li>
-                  <li>로그 데이터: 접속 기록, 기기/브라우저 정보(서비스 품질 개선 목적)</li>
-                </ul>
+              <article className="max-w-none text-slate-800 leading-relaxed">
+                <section className="space-y-3">
+                  <h2 className="text-xl sm:text-2xl font-extrabold text-slate-900">1. 총칙</h2>
+                  <p>루티드(Rooted, 이하 “회사”)는 이용자의 개인정보를 소중히 여기며, 개인정보 보호법, 정보통신망법 등 관련 법령을 준수합니다. 본 개인정보처리방침은 회사가 제공하는 웹/모바일 서비스 전반에 적용되며, 개인정보의 수집·이용·보관·파기에 관한 기준과 이용자의 권리 및 행사 방법을 명확히 안내합니다.</p>
+                </section>
 
-                <h2>2. 개인정보의 이용 목적</h2>
-                <ul>
-                  <li>회원 식별, 로그인 및 계정 관리</li>
-                  <li>서비스 제공, 운영 및 품질 개선</li>
-                  <li>고객 문의 응대, 공지/알림 전달, 보안 모니터링</li>
-                </ul>
+                <section className="space-y-3 mt-8">
+                  <h2 className="text-xl sm:text-2xl font-extrabold text-slate-900">2. 개인정보의 수집 및 이용목적</h2>
+                  <ul className="list-disc pl-5 space-y-1">
+                    <li>회원 식별 및 본인확인, 로그인 및 계정 관리</li>
+                    <li>커뮤니티 생성/가입, 게시글·댓글 작성 등 핵심 기능 제공</li>
+                    <li>활동 기반 포인트·레벨 산정, 통계/분석을 통한 서비스 품질 개선</li>
+                    <li>고객 문의 응대, 공지/알림 전달, 부정 이용 방지 및 보안 모니터링</li>
+                    <li>법령 준수, 분쟁 대응, 민원 처리 및 기록 보존</li>
+                  </ul>
+                </section>
 
-                <h2>3. 보관 기간 및 파기 절차</h2>
-                <ul>
-                  <li>관련 법령 또는 내부 정책에 따른 보관 기간을 준수합니다.</li>
-                  <li>목적 달성 시 지체 없이 안전한 방법으로 파기합니다(전자적 파일: 복구 불가 조치, 인쇄물: 분쇄).</li>
-                </ul>
+                <section className="space-y-3 mt-8">
+                  <h2 className="text-xl sm:text-2xl font-extrabold text-slate-900">3. 수집하는 개인정보 항목과 수집방법</h2>
+                  <div className="space-y-2">
+                    <h3 className="font-semibold text-slate-900">[회원]</h3>
+                    <ul className="list-disc pl-5 space-y-1">
+                      <li>필수: 이메일, 비밀번호(해시 처리), 사용자명/닉네임</li>
+                      <li>선택: 프로필 이미지, 자기소개, 소속/관심사</li>
+                      <li>로그/기기 정보: 접속 IP, 브라우저/OS, 접속 시간, 쿠키/세션 식별자</li>
+                    </ul>
+                  </div>
+                  <div className="space-y-2">
+                    <h3 className="font-semibold text-slate-900">[정기결제 회원]</h3>
+                    <ul className="list-disc pl-5 space-y-1">
+                      <li>필수: 결제 식별 정보(토큰화된 결제수단 식별자), 결제 이력(승인/취소 여부 등)</li>
+                      <li>청구/정산 목적의 최소 정보(전자영수증 이메일 등)</li>
+                      <li className="text-slate-600">결제정보(카드 번호 등 민감 정보)는 결제대행사(PG)에서 직접 처리하며, 회사는 원문을 보관하지 않습니다.</li>
+                    </ul>
+                  </div>
+                  <div className="space-y-2">
+                    <h3 className="font-semibold text-slate-900">[비회원]</h3>
+                    <ul className="list-disc pl-5 space-y-1">
+                      <li>고객 문의 시: 이메일, 이름(또는 닉네임), 문의 내용</li>
+                      <li>이벤트/프로모션 참여 시: 필수 동의 범위 내 최소 정보</li>
+                    </ul>
+                  </div>
+                  <div className="space-y-2">
+                    <h3 className="font-semibold text-slate-900">[기타]</h3>
+                    <ul className="list-disc pl-5 space-y-1">
+                      <li>이미지 업로드 시: 파일 메타데이터(파일명, 사이즈, MIME 등)</li>
+                      <li>서비스 보안/운영 목적: 오류 로그, 비정상 접근에 대한 탐지 정보</li>
+                    </ul>
+                  </div>
+                  <p className="text-slate-700">수집방법: 서비스 회원가입/이용 과정에서 이용자가 직접 입력, 서비스 이용 중 자동 생성(쿠키/세션/로그), 고객센터 문의, 이벤트 응모, 합법적 제휴사 제공 등.</p>
+                </section>
 
-                <h2>4. 제3자 제공 및 처리 위탁</h2>
-                <ul>
-                  <li>법령 근거 또는 이용자 동의가 있는 경우에 한하여 제공/위탁합니다.</li>
-                  <li>위탁 시 수탁자, 위탁 업무 범위, 보관 기간 등을 고지합니다.</li>
-                </ul>
+                <section className="space-y-3 mt-8">
+                  <h2 className="text-xl sm:text-2xl font-extrabold text-slate-900">4. 개인정보 제3자 제공</h2>
+                  <p>회사는 원칙적으로 이용자의 개인정보를 사전 동의 없이 제3자에게 제공하지 않습니다. 다만 다음의 경우 예외로 합니다.</p>
+                  <ul className="list-disc pl-5 space-y-1">
+                    <li>이용자가 사전에 제3자 제공에 명시적으로 동의한 경우</li>
+                    <li>법령에 근거가 있거나 수사기관의 적법한 절차에 따른 요청이 있는 경우</li>
+                    <li>서비스 제공을 위해 불가피한 범위에서 최소 정보만을 가명/익명 처리하여 제공하는 경우</li>
+                  </ul>
+                </section>
 
-                <h2>5. 이용자의 권리와 행사 방법</h2>
-                <ul>
-                  <li>이용자는 개인정보 열람, 정정/삭제, 처리정지 등을 요청할 수 있습니다.</li>
-                  <li>권리 행사는 고객센터 또는 계정 설정 페이지를 통해 가능합니다.</li>
-                </ul>
+                <section className="space-y-3 mt-8">
+                  <h2 className="text-xl sm:text-2xl font-extrabold text-slate-900">5. 개인정보 위탁 업무 및 수탁사 안내</h2>
+                  <p>원활한 서비스 제공을 위해 일부 업무를 외부 전문업체에 위탁할 수 있으며, 위탁 시 관련 법령에 따라 안전하게 관리되도록 감독합니다.</p>
+                  <ul className="list-disc pl-5 space-y-1">
+                    <li>인프라/호스팅: Vercel Inc. (서비스 서버/배포)</li>
+                    <li>데이터베이스/인증/스토리지: Supabase (로그인, DB, 서버리스, 일부 스토리지)</li>
+                    <li>이미지 스토리지: Cloudflare R2 (이미지 업로드/보관)</li>
+                    <li>이메일/알림: 도입 시 본 방침 또는 공지사항을 통해 고지</li>
+                    <li>결제/정기결제: 결제대행사(PG) 도입 시 수탁사, 위탁 업무, 보관 기간 등을 사전 고지</li>
+                  </ul>
+                </section>
 
-                <h2>6. 쿠키 및 유사 기술의 사용</h2>
-                <p>서비스 개선과 사용자 경험 향상을 위해 쿠키가 사용될 수 있으며, 브라우저 설정을 통해 거부할 수 있습니다.</p>
+                <section className="space-y-3 mt-8">
+                  <h2 className="text-xl sm:text-2xl font-extrabold text-slate-900">6. 개인정보의 처리 및 보유기간</h2>
+                  <ul className="list-disc pl-5 space-y-1">
+                    <li>원칙: 처리 목적 달성 후 또는 회원 탈퇴 시 지체 없이 파기합니다.</li>
+                    <li>예외: 법령에 따라 일정 기간 보관해야 하는 경우 아래 기간 동안 보관 후 파기합니다.</li>
+                  </ul>
+                  <div className="mt-2">
+                    <ul className="list-disc pl-5 space-y-1 text-slate-700">
+                      <li>계약/청약철회 등에 관한 기록: 5년 (전자상거래 등에서의 소비자보호에 관한 법률)</li>
+                      <li>대금결제 및 재화 등의 공급에 관한 기록: 5년 (전자상거래법)</li>
+                      <li>소비자 불만 또는 분쟁처리에 관한 기록: 3년 (전자상거래법)</li>
+                      <li>표시/광고에 관한 기록: 6개월 (전자상거래법)</li>
+                      <li>전자금융거래에 관한 기록: 5년 (전자금융거래법)</li>
+                      <li>접속 로그, 접속지 IP 등 서비스 방문 기록: 3개월 (통신비밀보호법)</li>
+                      <li>세법 등 관계 법령에 따른 거래 관련 장부/증빙: 5년 이상 (국세기본법 등)</li>
+                    </ul>
+                  </div>
+                </section>
 
-                <h2>7. 개인정보 안전성 확보 조치</h2>
-                <ul>
-                  <li>접근 권한 최소화, 암호화 저장(비밀번호 해시), 전송 구간 TLS 적용</li>
-                  <li>정기적 보안 점검 및 이상 징후 모니터링</li>
-                </ul>
+                <section className="space-y-3 mt-8">
+                  <h2 className="text-xl sm:text-2xl font-extrabold text-slate-900">7. 개인정보 파기절차 및 방법</h2>
+                  <ul className="list-disc pl-5 space-y-1">
+                    <li>파기절차: 보관 기간 만료 또는 처리 목적 달성 시 내부 검토 후 지체 없이 파기</li>
+                    <li>파기방법: 전자적 파일은 복구 불가능한 방식으로 영구 삭제, 출력물은 분쇄</li>
+                    <li>일부 정보는 법령에 따른 보관 의무로 인해 별도 DB로 분리 보관 후 기한 경과 시 즉시 파기</li>
+                  </ul>
+                </section>
 
-                <h2>8. 문의처</h2>
-                <p>개인정보 관련 문의는 서비스 내 문의 채널 또는 지원 메일로 연락해 주세요.</p>
+                <section className="space-y-3 mt-8">
+                  <h2 className="text-xl sm:text-2xl font-extrabold text-slate-900">8. 이용자의 권리와 행사 방법</h2>
+                  <ul className="list-disc pl-5 space-y-1">
+                    <li>이용자는 언제든지 본인의 개인정보에 대한 열람, 정정/삭제, 처리정지, 동의 철회를 요청할 수 있습니다.</li>
+                    <li>권리 행사는 서비스 내 설정 페이지 또는 아래 문의처를 통해 가능합니다. 대리인을 통한 행사도 가능합니다.</li>
+                    <li>요청 접수 시 회사는 지체 없이 처리하며, 법정 처리기한인 10일 이내 결과를 통지합니다. 불가피한 지연 시 지연 사유와 처리 계획을 안내합니다.</li>
+                    <li>법령상 보관이 요구되는 정보는 삭제/처리정지가 제한될 수 있으며, 이 경우 사유를 안내합니다.</li>
+                  </ul>
+                </section>
 
-                <p className="text-sm text-slate-500">최종 업데이트: 2025-09-08</p>
+                <section className="space-y-3 mt-8">
+                  <h2 className="text-xl sm:text-2xl font-extrabold text-slate-900">12. 미성년자 이용자에 관한 사항</h2>
+                  <ul className="list-disc pl-5 space-y-1">
+                    <li>만 14세 미만의 이용자는 법정대리인(보호자)의 동의가 필요한 경우가 있으며, 필요한 동의 절차를 별도로 안내합니다.</li>
+                    <li>미성년자는 커뮤니티 멤버로서 서비스 이용은 가능하나, 수익 창출 활동을 수행하는 커뮤니티 리더(판매/정산의 주체)가 될 수 없습니다.</li>
+                  </ul>
+                </section>
+
+                <section className="space-y-3 mt-8">
+                  <h2 className="text-xl sm:text-2xl font-extrabold text-slate-900">13. 광고성 정보 발송(마케팅의 활용)</h2>
+                  <ul className="list-disc pl-5 space-y-1">
+                    <li>회사는 이벤트, 혜택, 신규 기능 등의 정보를 제공하기 위해 광고성 정보를 발송할 수 있으며, 이는 사전 수신 동의를 받은 범위에서만 이루어집니다.</li>
+                    <li>이용자는 설정 페이지, 이메일 하단의 수신거부 링크 등으로 언제든지 수신을 거부할 수 있습니다.</li>
+                    <li>광고성 정보 수신 동의와 무관하게 서비스 운영에 필수적인 공지(보안/약관·정책 변경/중요 서비스 공지)는 발송될 수 있습니다.</li>
+                  </ul>
+                </section>
+
+                <section className="space-y-3 mt-8">
+                  <h2 className="text-xl sm:text-2xl font-extrabold text-slate-900">14. 책임 제한 및 유의사항</h2>
+                  <ul className="list-disc pl-5 space-y-1">
+                    <li>회사는 이용자의 과실(계정 공유/관리 소홀, 악성코드 감염 등) 또는 회사의 관리 범위를 벗어난 외부 서비스/링크/수탁사의 시스템 장애로 인한 손해에 대하여 법령이 허용하는 범위 내에서 책임을 부담하지 않습니다.</li>
+                    <li>가명/익명 처리된 통계·분석 자료는 개인 식별이 불가능한 형태로 활용되며, 해당 자료의 활용으로 특정 개인이 식별되는 경우를 제외하고 회사는 책임을 지지 않습니다.</li>
+                  </ul>
+                </section>
+
+                <section className="space-y-3 mt-8">
+                  <h2 className="text-xl sm:text-2xl font-extrabold text-slate-900">9. 개인정보 자동 수집 장치의 설치·운영 및 거부</h2>
+                  <ul className="list-disc pl-5 space-y-1">
+                    <li>회사는 서비스 품질 개선과 사용자 경험 향상을 위해 쿠키, 로컬 스토리지, 세션, 토큰 등을 사용할 수 있습니다.</li>
+                    <li>브라우저 설정에서 쿠키 저장을 거부하거나 삭제할 수 있으나, 일부 기능 이용에 제한이 있을 수 있습니다.</li>
+                    <li>인증 토큰은 보안을 위해 전송 구간에 TLS를 적용하며, 필요 시 만료/재발급 정책을 운영합니다.</li>
+                  </ul>
+                </section>
+
+                <section className="space-y-3 mt-8">
+                  <h2 className="text-xl sm:text-2xl font-extrabold text-slate-900">10. 개인정보보호를 위한 기술적·관리적 조치</h2>
+                  <ul className="list-disc pl-5 space-y-1">
+                    <li>접근통제: 최소 권한 원칙 적용, 역할 기반 접근 제어, 비정상 접근 탐지</li>
+                    <li>암호화: 비밀번호 해시 처리, 전송 구간 TLS 적용, 저장 데이터의 암호화(수탁 인프라 정책 준수)</li>
+                    <li>로그/감사: 중요 행위 로깅 및 이상 징후 모니터링</li>
+                    <li>관리적 조치: 정기적 권한 점검, 내부 보안 교육, 위탁사 관리·감독</li>
+                    <li>물리적 조치: 수탁 인프라 제공사의 데이터센터 보안 정책 준수</li>
+                  </ul>
+                </section>
+
+                <section className="space-y-3 mt-8">
+                  <h2 className="text-xl sm:text-2xl font-extrabold text-slate-900">11. 개인정보 보호책임자 안내</h2>
+                  <div className="space-y-1">
+                    <p>개인정보 보호책임자: 송규석</p>
+                    <p>이메일: <a className="underline underline-offset-2 text-slate-800 hover:text-slate-900" href="mailto:info@rooted.kr">info@rooted.kr</a></p>
+                    <p>주소: 서울특별시 서초구 서초동 1327-23</p>
+                  </div>
+                </section>
+
+                <section className="space-y-2 mt-8">
+                  <h2 className="text-xl sm:text-2xl font-extrabold text-slate-900">부칙</h2>
+                  <p>본 개인정보처리방침은 서비스 정책, 법령 또는 보안 요구사항의 변경에 따라 개정될 수 있으며, 중요한 변경 사항은 서비스 내 공지사항을 통해 사전에 안내합니다.</p>
+                  <div className="text-slate-700">
+                    <p>공고일자: 2025-10-08</p>
+                    <p>시행일자: 2025-10-08</p>
+                  </div>
+                </section>
+
+                <p className="mt-10 text-sm text-slate-500">최종 업데이트: 2025-10-08</p>
               </article>
             </CardContent>
           </Card>
+
+          {/* 하단 로고 + 슬로건 + 카피라이트 */}
+          <div className="mt-10 flex flex-col items-center gap-2 text-slate-700">
+            <div className="flex items-center gap-2">
+              <span className="relative" style={{ width: 22, height: 22 }}>
+                <Image src="/logos/logo_icon.png" alt="Rooted 아이콘" fill sizes="32px" className="object-contain" />
+              </span>
+              <span className="relative" style={{ width: 96, height: 28 }}>
+                <Image src="/logos/logo_main.png" alt="Rooted" fill sizes="120px" className="object-contain" />
+              </span>
+            </div>
+            <p className="text-sm text-slate-500">All in one 커뮤니티 플랫폼.</p>
+            <p className="text-xs text-slate-400">© 2025 Rooted. All rights reserved.</p>
+          </div>
         </div>
       </main>
     </div>

--- a/src/app/refund-policy/page.tsx
+++ b/src/app/refund-policy/page.tsx
@@ -1,0 +1,129 @@
+"use client"
+
+import AnimatedBackground from "@/components/AnimatedBackground"
+import { Card, CardContent } from "@/components/ui/card"
+import { Receipt } from "lucide-react"
+import Image from "next/image"
+
+export default function RefundPolicyPage() {
+  return (
+    <div className="min-h-screen relative">
+      <AnimatedBackground />
+      <main className="relative px-3 sm:px-4 md:px-6 lg:px-8 xl:px-10 pt-10 pb-24 z-10">
+        <div className="w-full max-w-4xl mx-auto">
+          <div className="mb-6 text-center">
+            <div className="flex items-center justify-center gap-3 mb-2">
+              <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-amber-400 to-amber-500 flex items-center justify-center shadow-lg ring-2 ring-white/60">
+                <Receipt className="w-5 h-5 text-white" />
+              </div>
+              <h1 className="text-3xl font-bold text-slate-900 tracking-tight">취소 및 환불 규정</h1>
+            </div>
+            <p className="text-slate-600">루티드(Rooted) 서비스의 유료 이용에 대한 취소/환불 기준을 안내합니다.</p>
+          </div>
+
+          <Card className="backdrop-blur-sm bg-white/80 border-slate-200/60 rounded-3xl shadow-xl">
+            <CardContent className="p-6 md:p-8">
+              <article className="max-w-none text-slate-800 leading-relaxed">
+                <section className="space-y-3">
+                  <h2 className="text-xl sm:text-2xl font-extrabold text-slate-900">제 1조 (목적 및 적용 대상)</h2>
+                  <p>본 규정은 루티드(Rooted, 이하 "회사")가 제공하는 유료 서비스(커뮤니티 운영 플랜, 멤버십 등)의 취소 및 환불 기준과 절차를 정하며, 서비스 내 고지된 별도 정책이 있는 경우 우선 적용합니다.</p>
+                </section>
+
+                <section className="space-y-3 mt-8">
+                  <h2 className="text-xl sm:text-2xl font-extrabold text-slate-900">제 2조 (정의)</h2>
+                  <ul className="list-disc pl-5 space-y-1">
+                    <li>"정기결제"란 일정 주기마다 자동으로 결제되는 유료 서비스 이용 형태를 말합니다.</li>
+                    <li>"디지털 콘텐츠/서비스 제공 개시"란 회원이 유료 서비스의 기능·혜택을 최초로 이용한 시점을 의미합니다.</li>
+                    <li>"리더/판매자"란 커뮤니티를 운영하며 유상 서비스를 제공하는 주체를 말합니다.</li>
+                  </ul>
+                </section>
+
+                <section className="space-y-3 mt-8">
+                  <h2 className="text-xl sm:text-2xl font-extrabold text-slate-900">제 3조 (취소 및 환불 신청기간)</h2>
+                  <ul className="list-disc pl-5 space-y-1">
+                    <li>정기결제: 다음 결제 예정일 최소 3영업일 전까지 해지 신청 시, 다음 주기부터 결제가 중단됩니다.</li>
+                    <li>단건 결제(전자상거래법상 청약철회): 디지털 콘텐츠/서비스의 제공이 개시되기 전에는 결제일로부터 7일 이내 청약철회가 가능합니다.</li>
+                    <li>제공 개시 후: 디지털 콘텐츠/서비스의 성질상 즉시 제공·복제가 가능한 경우 등 법령상 예외에 해당할 때에는 청약철회가 제한됩니다. 해당 예외 및 제한 사유는 서비스 내 고지를 따릅니다.</li>
+                    <li>커뮤니티 멤버십: 멤버십 시작일로부터 3일 이내 환불 신청이 가능하며, 이후에는 멤버십의 특성상 환불이 불가합니다.</li>
+                  </ul>
+                  <p className="text-sm text-slate-600">[참고] 전자상거래 등에서의 소비자보호에 관한 법률 및 같은 법 시행령을 따릅니다.</p>
+                </section>
+
+                <section className="space-y-3 mt-8">
+                  <h2 className="text-xl sm:text-2xl font-extrabold text-slate-900">제 4조 (취소 및 환불 절차)</h2>
+                  <ul className="list-disc pl-5 space-y-1">
+                    <li>회원은 서비스 내 설정 또는 고객센터를 통해 취소/환불을 신청합니다.</li>
+                    <li>회사는 접수 후 지체 없이 처리하며, 법령 및 내부 정책에 따라 필요한 확인 절차를 거칠 수 있습니다.</li>
+                    <li>환불 승인 시 원결제 수단을 우선으로 하되, 불가한 경우 대체 수단으로 환급할 수 있습니다.</li>
+                    <li>환불 승인 후 실제 결제 취소/환급 반영까지는 카드사 또는 결제대행사(PG) 정책에 따라 영업일 기준 3~7일이 소요될 수 있습니다. 계좌 환급의 경우 은행 영업일 및 내부 처리 절차에 따라 추가 시간이 소요될 수 있습니다.</li>
+                  </ul>
+                </section>
+
+                <section className="space-y-3 mt-8">
+                  <h2 className="text-xl sm:text-2xl font-extrabold text-slate-900">제 5조 (취소 및 환불 수수료)</h2>
+                  <ul className="list-disc pl-5 space-y-1">
+                    <li>제공 개시 전 환불: 결제대행 수수료(PG), 플랫폼 이용료 등 실비가 공제될 수 있습니다.</li>
+                    <li>제공 개시 후 환불 제한: 법령상 예외 사유(하자 등)가 없는 한 환불이 제한됩니다. 예외 적용 시에도 아래 공제 기준이 적용될 수 있습니다.</li>
+                    <li>부분 이용 관련 공식 기준: 
+                      <ul className="list-disc pl-5 space-y-1">
+                        <li>커뮤니티 플랜 월 정기결제: 일할 계산을 적용하지 않으며, 해당 결제 주기의 남은 기간 환불은 불가합니다.</li>
+                        <li>커뮤니티 플랜 연간 결제: 서비스 내 고지된 환불 정책에 따라 잔여 개월 수 기준의 환불 가능 여부 및 공제 기준을 사전에 안내합니다.</li>
+                        <li>커뮤니티 멤버십: 멤버십 시작 후 3일 이내에는 환불이 가능하나, 이후에는 커뮤니티 멤버십의 특성상 환불이 불가합니다.</li>
+                      </ul>
+                    </li>
+                    <li>공제 항목 예시: 이미 제공된 기간·혜택에 대한 사용액, 결제/정산 비용(PG 수수료 등), 부가가치세 정산 차액, 프로모션·쿠폰 차감액 등.</li>
+                    <li>세무·원천징수 처리: 이미 세금계산서/현금영수증이 발행되었거나 정산이 완료된 건의 환불은 다음 기준에 따릅니다.
+                      <ul className="list-disc pl-5 space-y-1">
+                        <li>가능한 경우 계산서/영수증의 취소·수정 발행 및 세액 재계산을 진행합니다.</li>
+                        <li>정산 완료된 금액은 차기 정산금에서 차감(상계)하거나, 판매자/리더에게 환수 청구할 수 있습니다.</li>
+                      </ul>
+                    </li>
+                    <li>구체적 수수료, 공제 항목 및 요율은 서비스 내 고지된 환불정책을 따릅니다.</li>
+                  </ul>
+                </section>
+
+                <section className="space-y-3 mt-8">
+                  <h2 className="text-xl sm:text-2xl font-extrabold text-slate-900">제 6조 (판매자의 중도 취소 및 변경 시 환불)</h2>
+                  <ul className="list-disc pl-5 space-y-1">
+                    <li>리더/판매자의 귀책으로 유료 서비스 제공이 취소·중단·현저히 변경되는 경우, 회사는 관련 사실을 확인하여 전부 또는 일부 환불을 지원합니다.</li>
+                    <li>회사는 통신판매중개자로서 환불 절차를 중개·지원할 뿐이며, 판매자의 채무에 대하여 연대책임을 지지 않습니다. 다만, 법령상 회사가 부담하는 책임이 있는 경우 그 범위 내에서만 책임을 집니다.</li>
+                    <li>이미 정산된 금액이 있는 경우 회사는 차기 정산에서 상계하거나, 판매자/리더에게 환수 청구할 수 있습니다.</li>
+                    <li>환불 기준과 방식은 서비스 내 고지된 정책 및 전자상거래법 등 관계 법령에 따릅니다.</li>
+                  </ul>
+                </section>
+
+                <section className="space-y-2 mt-8">
+                  <h2 className="text-xl sm:text-2xl font-extrabold text-slate-900">부칙</h2>
+                  <p>본 규정은 서비스 정책, 법령 또는 결제/정산 환경의 변경에 따라 개정될 수 있으며, 중요한 변경 사항은 서비스 내 공지사항을 통해 안내합니다.</p>
+                  <div className="text-slate-700">
+                    <p>공고일자: 2025-10-08</p>
+                    <p>시행일자: 2025-10-08</p>
+                  </div>
+                </section>
+
+                <p className="mt-10 text-sm text-slate-500">최종 업데이트: 2025-10-08</p>
+              </article>
+            </CardContent>
+          </Card>
+
+          <div className="mt-10 border-t border-slate-200" />
+
+          {/* 하단 로고 + 카피라이트 */}
+          <div className="mt-6 flex flex-col items-center gap-2 text-slate-700">
+            <div className="flex items-center gap-2">
+              <span className="relative" style={{ width: 22, height: 22 }}>
+                <Image src="/logos/logo_icon.png" alt="Rooted 아이콘" fill sizes="32px" className="object-contain" />
+              </span>
+              <span className="relative" style={{ width: 96, height: 28 }}>
+                <Image src="/logos/logo_main.png" alt="Rooted" fill sizes="120px" className="object-contain" />
+              </span>
+            </div>
+            <p className="text-xs text-slate-400">© 2025 Rooted. All rights reserved.</p>
+          </div>
+        </div>
+      </main>
+    </div>
+  )
+}
+
+

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -160,7 +160,7 @@ export default function SignUpPage() {
         </CardContent>
       </Card>
 
-      <div className="mt-6 text-xs text-slate-600">
+      <div className="mt-6 text-sm text-slate-600">
         <Link href="/terms" className="hover:underline">이용약관</Link>
         <span className="px-2">|</span>
         <Link href="/privacy" className="hover:underline">개인정보처리방침</Link>

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -3,6 +3,7 @@
 import AnimatedBackground from "@/components/AnimatedBackground"
 import { Card, CardContent } from "@/components/ui/card"
 import { FileText } from "lucide-react"
+import Image from "next/image"
 
 export default function TermsPage() {
   return (
@@ -22,65 +23,203 @@ export default function TermsPage() {
 
           <Card className="backdrop-blur-sm bg-white/80 border-slate-200/60 rounded-3xl shadow-xl">
             <CardContent className="p-6 md:p-8">
-              <article className="prose prose-slate max-w-none">
-                <h2>제1조 (목적)</h2>
-                <p>본 약관은 루티드(이하 "회사")가 제공하는 서비스의 이용과 관련하여 회사와 이용자 간의 권리, 의무 및 책임사항을 정함을 목적으로 합니다.</p>
+              <article className="max-w-none text-slate-800 leading-relaxed">
+                <section className="space-y-3">
+                  <h2 className="text-xl sm:text-2xl font-extrabold text-slate-900">[제 1장] 총칙</h2>
+                  <h3 className="text-lg sm:text-xl font-bold text-slate-900">제 1조 (목적)</h3>
+                  <p>본 약관은 루티드(Rooted, 이하 “회사”)가 제공하는 웹/모바일 기반 커뮤니티 플랫폼(이하 “서비스”)의 이용과 관련하여 회사와 이용자 간 권리, 의무 및 책임사항, 서비스 이용절차 및 조건 등 제반 사항을 규정함을 목적으로 합니다.</p>
+                  <h3 className="text-lg sm:text-xl font-bold text-slate-900">제 2조 (약관의 효력 및 변경)</h3>
+                  <ul className="list-disc pl-5 space-y-1">
+                    <li>본 약관은 서비스 화면에 게시함으로써 효력이 발생합니다.</li>
+                    <li>회사는 관련 법령을 위배하지 않는 범위에서 약관을 변경할 수 있으며, 변경 시 사전 공지합니다.</li>
+                    <li>이용자가 공지일로부터 7일(중대한 변경은 30일) 내 이의를 제기하지 않은 경우 변경 약관에 동의한 것으로 봅니다.</li>
+                  </ul>
+                  <h3 className="text-lg sm:text-xl font-bold text-slate-900">제 3조 (용어의 정의)</h3>
+                  <ul className="list-disc pl-5 space-y-1">
+                    <li>“이용자”: 본 약관에 따라 서비스를 이용하는 회원 및 비회원</li>
+                    <li>“회원”: 서비스에 가입하여 지속적으로 이용하는 자</li>
+                    <li>“커뮤니티”: 회원이 개설하거나 가입하여 활동하는 공간</li>
+                    <li>“리더”: 커뮤니티 운영 권한을 가진 회원</li>
+                    <li>“멤버”: 커뮤니티에 가입하여 활동하는 회원</li>
+                  </ul>
+                </section>
 
-                <h2>제2조 (정의)</h2>
-                <ul>
-                  <li>"서비스"란 회사가 제공하는 웹/모바일 기반의 커뮤니티 플랫폼 일체를 의미합니다.</li>
-                  <li>"이용자"란 본 약관에 따라 서비스를 이용하는 회원 및 비회원을 말합니다.</li>
-                  <li>"회원"이란 서비스에 가입하여 지속적으로 이용하는 자를 의미합니다.</li>
-                </ul>
+                <section className="space-y-3 mt-8">
+                  <h2 className="text-xl sm:text-2xl font-extrabold text-slate-900">[제 2장] 서비스 이용계약</h2>
+                  <h3 className="text-lg sm:text-xl font-bold text-slate-900">제 4조 (계약의 성립: 회원가입)</h3>
+                  <ul className="list-disc pl-5 space-y-1">
+                    <li>이용계약은 이용자가 약관에 동의하고 회원가입 양식을 제출하며, 회사가 이를 승낙함으로써 성립합니다.</li>
+                    <li>만 14세 미만의 아동은 보호자의 동의가 확인된 경우에 한하여 회원가입이 가능하며, 필요한 절차를 별도로 안내합니다.</li>
+                    <li>미성년자는 커뮤니티 멤버로서 서비스 이용은 가능하나, 수익 창출 활동을 수행하는 커뮤니티 리더(판매/정산의 주체)가 될 수 없습니다.</li>
+                  </ul>
+                  <h3 className="text-lg sm:text-xl font-bold text-slate-900">제 5조 (이용신청의 승낙과 제한)</h3>
+                  <ul className="list-disc pl-5 space-y-1">
+                    <li>회사는 서비스 제공에 지장이 없는 범위에서 신청을 원칙적으로 승낙합니다.</li>
+                    <li>다만, 다음의 경우 승낙을 유보하거나 거절할 수 있습니다: 허위 정보 기재, 타인 정보 도용, 법령·약관 위반, 설비 여유 부족 등.</li>
+                  </ul>
+                </section>
 
-                <h2>제3조 (약관의 게시 및 변경)</h2>
-                <ul>
-                  <li>회사는 본 약관을 서비스 내 화면에 게시합니다.</li>
-                  <li>관련 법령을 위배하지 않는 범위에서 약관을 변경할 수 있으며, 변경 시 개정 내용을 서비스 내에 공지합니다.</li>
-                  <li>이용자가 공지일로부터 7일 이내에 이의를 제기하지 않은 경우 변경 약관에 동의한 것으로 봅니다.</li>
-                </ul>
+                <section className="space-y-3 mt-8">
+                  <h2 className="text-xl sm:text-2xl font-extrabold text-slate-900">[제 3장] 서비스 이용</h2>
+                  <h3 className="text-lg sm:text-xl font-bold text-slate-900">제 6조 (서비스 내용)</h3>
+                  <ul className="list-disc pl-5 space-y-1">
+                    <li>커뮤니티 생성/가입, 게시글·댓글, 일정/수업 관리, 포인트·레벨 등 기능 제공</li>
+                    <li>알림/공지, 마이페이지, 통계/분석, 이미지 업로드 등 부가 기능 제공</li>
+                  </ul>
+                  <h3 className="text-lg sm:text-xl font-bold text-slate-900">제 7조 (통신판매중개서비스의 이용)</h3>
+                  <ul className="list-disc pl-5 space-y-1">
+                    <li>회사는 통신판매중개자로서 거래 당사자가 아니며, 상품/서비스에 대한 책임은 판매자에게 있습니다.</li>
+                    <li>회사는 중개 시스템 제공 및 결제 연동 등 플랫폼 기능을 제공합니다.</li>
+                  </ul>
+                  <h3 className="text-lg sm:text-xl font-bold text-slate-900">제 8조 (커뮤니티 서비스의 이용)</h3>
+                  <ul className="list-disc pl-5 space-y-1">
+                    <li>리더는 커뮤니티 운영 정책을 수립·고지할 수 있으며, 약관 및 법령을 준수해야 합니다.</li>
+                    <li>멤버는 커뮤니티 규칙을 준수하여 활동해야 하며, 위반 시 제재될 수 있습니다.</li>
+                  </ul>
+                  <h3 className="text-lg sm:text-xl font-bold text-slate-900">제 9조 (서비스 이용조건)</h3>
+                  <ul className="list-disc pl-5 space-y-1">
+                    <li>이용자는 정상적인 인터넷 환경과 호환되는 기기를 보유해야 합니다.</li>
+                    <li>일부 기능은 최신 브라우저/환경에서만 지원될 수 있습니다.</li>
+                  </ul>
+                  <h3 className="text-lg sm:text-xl font-bold text-slate-900">제 10조 (서비스의 변경 및 중단)</h3>
+                  <ul className="list-disc pl-5 space-y-1">
+                    <li>운영상·기술상 필요에 따라 서비스 내용이 변경되거나 중단될 수 있으며, 가능한 범위에서 사전 또는 사후 공지합니다.</li>
+                    <li>천재지변, 장애, 보안 위협 등 부득이한 경우 사전 고지 없이 변경·중단될 수 있으며, 이로 인한 손해에 대해 회사는 고의 또는 중대한 과실이 없는 한 책임지지 않습니다.</li>
+                  </ul>
+                  <h3 className="text-lg sm:text-xl font-bold text-slate-900">제 11조 (회원정보의 변경)</h3>
+                  <p>회원은 등록 정보가 변경된 경우 지체 없이 서비스 내 설정을 통해 수정하여야 합니다.</p>
+                  <h3 className="text-lg sm:text-xl font-bold text-slate-900">제 12조 (고객의 아이디 및 비밀번호 관리)</h3>
+                  <ul className="list-disc pl-5 space-y-1">
+                    <li>계정과 비밀번호의 관리책임은 회원에게 있으며, 도용/유출이 발생한 경우 지체 없이 회사에 통지해야 합니다.</li>
+                    <li>회사는 필요한 경우 안전한 인증수단 변경·재발급 정책을 시행할 수 있습니다.</li>
+                  </ul>
+                  <h3 className="text-lg sm:text-xl font-bold text-slate-900">제 13조 (정보 제공 및 마케팅의 활용)</h3>
+                  <ul className="list-disc pl-5 space-y-1">
+                    <li>회사는 서비스 관련 공지, 운영 알림을 제공할 수 있습니다.</li>
+                    <li>광고성 정보는 사전 수신동의를 받은 범위에서 전송하며, 수신 거부가 가능합니다.</li>
+                  </ul>
+                </section>
 
-                <h2>제4조 (계정 및 보안)</h2>
-                <ul>
-                  <li>회원은 본인의 책임 하에 계정 및 비밀번호를 관리하여야 합니다.</li>
-                  <li>타인의 정보 도용, 공유 등 부정 사용이 확인될 경우 회사는 이용 정지 또는 해지할 수 있습니다.</li>
-                </ul>
+                <section className="space-y-3 mt-8">
+                  <h2 className="text-xl sm:text-2xl font-extrabold text-slate-900">[제 4장] 서비스 이용의 책임과 의무</h2>
+                  <h3 className="text-lg sm:text-xl font-bold text-slate-900">제 14조 (회사의 의무)</h3>
+                  <ul className="list-disc pl-5 space-y-1">
+                    <li>회사는 관련 법령과 약관을 준수하며, 안정적인 서비스 제공을 위해 최선을 다합니다.</li>
+                    <li>이용자 불만 처리 및 분쟁 해결을 위해 합리적으로 노력합니다.</li>
+                  </ul>
+                  <h3 className="text-lg sm:text-xl font-bold text-slate-900">제 15조 (회원의 의무) : 커뮤니티 리더, 커뮤니티 멤버</h3>
+                  <ul className="list-disc pl-5 space-y-1">
+                    <li>리더: 커뮤니티 운영·정산에 관한 책임과 의무를 지며, 법령·약관·정책을 준수합니다.</li>
+                    <li>멤버: 커뮤니티 규칙과 공지사항을 준수하며, 타인의 권리를 침해하지 않습니다.</li>
+                    <li>회원은 본인이 제공·판매·게시한 콘텐츠/상품/서비스와 관련하여 발생한 모든 법적 책임(저작권·상표권 침해, 세금·환불·분쟁 등)에 대해 회사를 면책하며, 회사가 대신 배상·환불·과징금 등을 부담한 경우 해당 금액 전부를 회사에 구상당할 수 있습니다.</li>
+                  </ul>
+                  <h3 className="text-lg sm:text-xl font-bold text-slate-900">제 16조 (수익의 지급 및 정산)</h3>
+                  <ul className="list-disc pl-5 space-y-1">
+                    <li>리더 또는 판매자에게 발생하는 수익은 회사가 정한 정산 주기·방법에 따라 지급되며, 부가가치세 및 PG사의 결제대행 수수료, 플랫폼 이용료 등을 공제 후 지급됩니다.</li>
+                    <li>공제 항목 및 요율은 서비스 내 고지된 정책을 따르며, 정책 변경 시 적용 시점 및 범위를 사전에 안내합니다.</li>
+                    <li>정산 기준과 절차는 서비스 내 또는 별도 정책으로 고지합니다.</li>
+                  </ul>
+                  <h3 className="text-lg sm:text-xl font-bold text-slate-900">제 17조 (커뮤니티 이용의 금지 행위)</h3>
+                  <ul className="list-disc pl-5 space-y-1">
+                    <li>불법·유해 정보 유포, 타인 비방/괴롭힘, 지식재산권 침해, 스팸/광고 행위</li>
+                    <li>서비스 취약점 악용, 시스템 무단 접근, 자동화 도구로의 비정상 이용</li>
+                    <li>회원의 불법 콘텐츠/행위로 인해 제3자·기관으로부터 발생하는 민형사·행정상 제재, 세금·환불 요구 등 일체의 책임은 회원에게 있으며, 회사는 연대 책임을 부담하지 않습니다.</li>
+                  </ul>
+                  <h3 className="text-lg sm:text-xl font-bold text-slate-900">제 18조 (회원에 대한 통지)</h3>
+                  <ul className="list-disc pl-5 space-y-1">
+                    <li>회사는 회원의 등록 이메일, 서비스 내 알림 등으로 통지할 수 있습니다.</li>
+                    <li>불특정 다수에 대한 통지는 서비스 내 공지로 갈음할 수 있습니다.</li>
+                  </ul>
+                  <h3 className="text-lg sm:text-xl font-bold text-slate-900">제 19조 (개인정보의 수집과 보호 및 이용)</h3>
+                  <p>개인정보의 수집, 이용, 보관, 파기 등은 회사의 개인정보처리방침에 따릅니다.</p>
+                  <h3 className="text-lg sm:text-xl font-bold text-slate-900">제 20조 (게시물의 관리)</h3>
+                  <ul className="list-disc pl-5 space-y-1">
+                    <li>커뮤니티의 저작권은 원칙적으로 리더에게 귀속됩니다. 다만, 회사는 서비스 운영, 검색 노출 최적화, 서비스·커뮤니티 홍보 등을 위해 해당 게시물을 전 세계적으로 비독점적·무상으로 사용, 저장, 복제, 전시, 배포, 2차적 저작물 제작(썸네일/리사이즈/스크린샷 포함)할 수 있는 사용권을 가집니다. 회원은 필요한 범위의 이용권 부여에 동의합니다.</li>
+                    <li>회사는 저작권을 가진 커뮤니티 리더의 유료 콘텐츠 및 지적 재산을 플랫폼 내 필요 서비스 외 수익을 위한 상업적으로 이용하지 않습니다.</li>
+                    <li>회사는 약관·정책 위반, 권리침해, 법령 위반 소지가 있는 게시물에 대해 사전 통지 없이 삭제·이동·비공개 처리할 수 있습니다.</li>
+                  </ul>
+                  <h3 className="text-lg sm:text-xl font-bold text-slate-900">제 21조 (결제 대행 및 결제 대금 보호 서비스의 이용)</h3>
+                  <ul className="list-disc pl-5 space-y-1">
+                    <li>결제는 결제대행사(PG)를 통해 처리되며, 회사는 PG의 결제 절차를 연동 제공합니다.</li>
+                    <li>PG사 정책 변경, 장애 등으로 결제가 제한될 수 있으며, 해당 경우 회사는 합리적으로 대응합니다.</li>
+                  </ul>
+                  <h3 className="text-lg sm:text-xl font-bold text-slate-900">제 22조 (권리의 귀속)</h3>
+                  <ul className="list-disc pl-5 space-y-1">
+                    <li>서비스와 관련된 지식재산권은 회사 또는 정당한 권리자에게 귀속됩니다.</li>
+                    <li>회원이 서비스에 업로드하는 콘텐츠는 제20조에 따른 범위에서 회사가 이용할 수 있습니다.</li>
+                    <li>이용자는 회사의 사전 서면 동의 없이 서비스 자료를 무단 이용할 수 없습니다.</li>
+                  </ul>
+                </section>
 
-                <h2>제5조 (서비스의 제공, 변경 및 중단)</h2>
-                <ul>
-                  <li>회사는 안정적인 서비스 제공을 위해 최선을 다합니다.</li>
-                  <li>운영상·기술상 필요 시 서비스 내용을 변경하거나 중단할 수 있으며, 사전 공지합니다. 긴급한 사유가 있는 경우 사후 공지할 수 있습니다.</li>
-                </ul>
+                <section className="space-y-3 mt-8">
+                  <h2 className="text-xl sm:text-2xl font-extrabold text-slate-900">[제 5장] 유료 서비스 이용 및 결제</h2>
+                  <h3 className="text-lg sm:text-xl font-bold text-slate-900">제 23조 (유료 서비스 이용 계약) : 커뮤니티 운영 Plan / 유저 멤버십 결제</h3>
+                  <ul className="list-disc pl-5 space-y-1">
+                    <li>회사 또는 리더가 제공하는 유료 플랜/멤버십에 대한 계약은 주문 완료 시 성립합니다.</li>
+                    <li>제공 범위와 가격, 기간, 혜택은 서비스 내 안내에 따릅니다.</li>
+                  </ul>
+                  <h3 className="text-lg sm:text-xl font-bold text-slate-900">제 24조 (유료 서비스의 주문 및 결제)</h3>
+                  <ul className="list-disc pl-5 space-y-1">
+                    <li>결제 수단은 PG사를 통해 제공되며, 결제 승인 시점에 요금이 청구됩니다.</li>
+                    <li>세금계산서/영수증 등 증빙은 정책에 따라 제공됩니다.</li>
+                  </ul>
+                  <h3 className="text-lg sm:text-xl font-bold text-slate-900">제 25조 (유료 서비스 청약해지 및 정기결제 중단)</h3>
+                  <ul className="list-disc pl-5 space-y-1">
+                    <li>정기결제는 서비스 내에서 해지 신청할 수 있으며, 다음 결제 주기부터 중단됩니다.</li>
+                    <li>전자상거래법 등 관련 법령에 따라 청약철회가 제한될 수 있습니다. 특히 디지털 콘텐츠의 제공이 개시된 경우, 전부 또는 일부 이용이 이루어진 경우, 시간 경과로 재판매가 곤란한 경우 등에는 환불이 제한됩니다.</li>
+                    <li>부분 이용이 있는 경우 잔여기간 환불은 제한될 수 있으며, 세부 기준은 환불정책 및 서비스 내 고지에 따릅니다.</li>
+                    <li>커뮤니티 멤버십의 경우: 멤버십 시작일로부터 3일 이내에는 환불이 가능하나, 이후에는 커뮤니티 특성상 환불이 불가합니다. 구체 기준은 환불정책을 따릅니다.</li>
+                  </ul>
+                  <h3 className="text-lg sm:text-xl font-bold text-slate-900">제 26조 (유료 서비스 이용의 변경)</h3>
+                  <ul className="list-disc pl-5 space-y-1">
+                    <li>플랜 업그레이드/다운그레이드 시 차액 정산, 기간 변경 등은 서비스 정책에 따르며, 제공이 개시된 디지털 콘텐츠/서비스에 대해서는 환불이 제한될 수 있습니다.</li>
+                    <li>혜택 또는 가격 변경 시 가능한 범위에서 사전 공지하며, 부득이한 경우 사후 공지할 수 있습니다.</li>
+                  </ul>
+                </section>
 
-                <h2>제6조 (콘텐츠와 지식재산권)</h2>
-                <ul>
-                  <li>서비스 및 이에 포함된 콘텐츠에 대한 저작권과 모든 지식재산권은 회사 또는 해당 권리자에게 귀속됩니다.</li>
-                  <li>이용자는 회사의 사전 동의 없이 서비스 내 자료를 복제, 배포, 전송, 2차적 저작물 작성 등 할 수 없습니다.</li>
-                </ul>
+                <section className="space-y-3 mt-8">
+                  <h2 className="text-xl sm:text-2xl font-extrabold text-slate-900">[제 6장] 이용계약 해지 등</h2>
+                  <h3 className="text-lg sm:text-xl font-bold text-slate-900">제 27조 (서비스의 탈퇴 또는 이용제한)</h3>
+                  <ul className="list-disc pl-5 space-y-1">
+                    <li>회원은 언제든지 탈퇴할 수 있으며, 약관/정책 위반 시 회사는 이용 제한 또는 계약 해지할 수 있습니다.</li>
+                    <li>부정 이용, 불법 행위, 타인 권리 침해 등에 대하여 서비스 이용이 제한될 수 있습니다.</li>
+                  </ul>
+                  <h3 className="text-lg sm:text-xl font-bold text-slate-900">제 28조 (손해배상 등)</h3>
+                  <ul className="list-disc pl-5 space-y-1">
+                    <li>이용자의 귀책사유로 회사에 손해가 발생한 경우, 해당 이용자는 그 손해를 배상하여야 합니다.</li>
+                    <li>회원의 위법행위·약관/정책 위반으로 인해 회사가 제3자에게 배상·환불·과징금 등을 지급한 때에는, 회사는 해당 회원에게 그 전액 및 합리적 비용을 구상 청구할 수 있습니다.</li>
+                  </ul>
+                  <h3 className="text-lg sm:text-xl font-bold text-slate-900">제 29조 (면책조항)</h3>
+                  <ul className="list-disc pl-5 space-y-1">
+                    <li>천재지변, 불가항력, 제3자 귀책, 이용자 귀책 등으로 인한 손해에 대하여 회사는 책임을 지지 않습니다.</li>
+                    <li>이용자 상호 간 또는 이용자와 제3자 간 분쟁에 대하여 회사는 개입하지 않으며 책임을 지지 않습니다.</li>
+                  </ul>
+                  <h3 className="text-lg sm:text-xl font-bold text-slate-900">제 30조 (분쟁해결)</h3>
+                  <ul className="list-disc pl-5 space-y-1">
+                    <li>분쟁은 관련 법령과 상관례에 따라 합리적으로 해결하기 위해 노력합니다.</li>
+                    <li>본 약관은 대한민국 법령을 준거로 하며, 관할은 회사 본점 소재지 관할 법원으로 합니다.</li>
+                  </ul>
+                </section>
 
-                <h2>제7조 (금지행위)</h2>
-                <ul>
-                  <li>법령 또는 미풍양속에 위반되는 행위</li>
-                  <li>타인의 권리(저작권, 상표권 등)를 침해하는 행위</li>
-                  <li>서비스의 정상적인 운영을 방해하는 행위(스팸, 과도한 트래픽 유발 등)</li>
-                </ul>
-
-                <h2>제8조 (면책 및 책임의 제한)</h2>
-                <ul>
-                  <li>회사는 천재지변, 불가항력, 이용자 귀책 등으로 발생한 손해에 대해 책임을 지지 않습니다.</li>
-                  <li>회사는 이용자 상호 간 또는 이용자와 제3자 간에 발생한 분쟁에 개입하지 않으며, 그에 따른 손해에 대해 책임을 지지 않습니다.</li>
-                </ul>
-
-                <h2>제9조 (손해배상)</h2>
-                <p>이용자가 본 약관을 위반함으로써 회사에 손해가 발생한 경우, 해당 이용자는 회사가 입은 손해를 배상하여야 합니다.</p>
-
-                <h2>제10조 (준거법 및 관할)</h2>
-                <p>본 약관은 대한민국 법령에 따르며, 분쟁 발생 시 회사의 본점 소재지를 관할하는 법원을 전속 관할로 합니다.</p>
-
-                <p className="text-sm text-slate-500">최종 업데이트: 2025-09-08</p>
+                <p className="mt-10 text-sm text-slate-500">최종 업데이트: 2025-10-08</p>
               </article>
             </CardContent>
           </Card>
+
+          <div className="mt-10 border-t border-slate-200" />
+
+          {/* 하단 로고 + 카피라이트 */}
+          <div className="mt-6 flex flex-col items-center gap-2 text-slate-700">
+            <div className="flex items-center gap-2">
+              <span className="relative" style={{ width: 22, height: 22 }}>
+                <Image src="/logos/logo_icon.png" alt="Rooted 아이콘" fill sizes="32px" className="object-contain" />
+              </span>
+              <span className="relative" style={{ width: 96, height: 28 }}>
+                <Image src="/logos/logo_main.png" alt="Rooted" fill sizes="120px" className="object-contain" />
+              </span>
+            </div>
+            <p className="text-xs text-slate-400">© 2025 Rooted. All rights reserved.</p>
+          </div>
         </div>
       </main>
     </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -49,6 +49,7 @@ export default function Footer() {
             <ul className="mt-3 space-y-2 text-sm text-slate-400">
               <li><Link className="hover:text-white" href="/privacy">개인정보 처리방침</Link></li>
               <li><Link className="hover:text-white" href="/terms">이용약관</Link></li>
+              <li><Link className="hover:text-white" href="/refund-policy">취소 및 환불 규정</Link></li>
             </ul>
           </div>
         </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -136,8 +136,8 @@ export function Header() {
           {!isCommunityRootPage ? (
             <div className="md:hidden flex items-center justify-center">
               <Link href="/" className="flex items-center">
-                <Image src="/logos/logo_icon.png" alt="Rooted" width={28} height={28} className="w-7 h-7" priority />
-                <span className="relative ml-1" style={{ width: 100, height: 20 }}>
+                <Image src="/logos/logo_icon.png" alt="Rooted" width={28} height={28} className="w-6 h-5" priority />
+                <span className="relative -ml-1" style={{ width: 90, height: 18 }}>
                   <Image src="/logos/logo_main.png" alt="Rooted" fill priority sizes="100px" className="object-contain" />
                 </span>
               </Link>
@@ -157,8 +157,8 @@ export function Header() {
             <div className={`w-full rounded-lg border h-12 px-3.5 flex items-center gap-3 relative ${isHome ? 'border-white/90 shadow-[0_0_38px_rgba(255,255,255,0.32)] hover:shadow-[0_0_36px_rgba(255,255,255,0.52)] ring-1 ring-white/60 hover:ring-white/80' : 'border-slate-300 shadow-[0_0_14px_rgba(148,163,184,0.28)] hover:shadow-[0_0_20px_rgba(148,163,184,0.4)]'}`} style={capsuleStyle} ref={desktopDropdownRef}>
               {/* Left: Logo */}
               <Link href="/" className="flex items-center hover:opacity-95">
-                <Image src="/logos/logo_icon.png" alt="Rooted 아이콘" width={24} height={24} className="w-6 h-6" priority />
-                <span className="relative ml-1" style={{ width: 82, height: 24 }}>
+                <Image src="/logos/logo_icon.png" alt="Rooted 아이콘" width={24} height={24} className="w-7 h-6" priority />
+                <span className="relative ml-0" style={{ width: 82, height: 24 }}>
                   <Image src="/logos/logo_main.png" alt="Rooted" fill priority sizes="110px" className="object-contain" />
                 </span>
               </Link>

--- a/src/components/community-dashboard/PageContent.tsx
+++ b/src/components/community-dashboard/PageContent.tsx
@@ -35,7 +35,11 @@ export function PageContent({ pageId }: PageContentProps) {
           // 폴백: 타입 컬럼이 없거나 비어있을 때 테이블 존재로 추정
           try {
             const supa = (await import('@/lib/supabase')).supabase
-            const { data: blogProbe } = await supa.from('community_page_blog_posts').select('id').eq('page_id', pageId).limit(1)
+            const { data: blogProbe } = await supa
+              .from('community_page_blog_posts')
+              .select('id', { count: 'exact', head: true })
+              .eq('page_id', pageId)
+              .limit(1)
             if ((blogProbe as any)?.length > 0) setType('blog')
             else setType('feed')
           } catch {


### PR DESCRIPTION
…mance tweaks\n\n- Privacy: add legal retention periods, minor policy updates\n- Terms: settlement, refunds, IP license, minors, liability, service changes\n- Refund Policy: standalone page + footer link; legal withdrawal/partial rules, PG timing\n- Perf: cache strategy for public community page, slimmer selects, Next/Image tuning, lazy background\n- Misc: minor queries optimization and placeholders