### PR TITLE
11.13 링크 처리, 링크 박스, 캘린더 섹션, 스켈레톤 제거

### DIFF
--- a/src/app/[slug]/ClientPage.tsx
+++ b/src/app/[slug]/ClientPage.tsx
@@ -8,9 +8,9 @@ import dynamic from 'next/dynamic'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
-import { Users, Crown, ArrowLeft, UserPlus, Check, Info, X, Clock, Loader2, Gift } from 'lucide-react'
+import { Users, Crown, ArrowLeft, UserPlus, Check, Info, X, Clock, Loader2, Gift, ChevronRight } from 'lucide-react'
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
-import { joinCommunity, leaveCommunity } from '@/lib/communities'
+import { joinCommunity, leaveCommunity, getCommunityLinkBoxes } from '@/lib/communities'
 import { useAuthData } from '@/components/auth/AuthProvider'
 import { toast } from 'sonner'
 
@@ -54,6 +54,7 @@ export default function ClientCommunityPage({ initial }: { initial?: any }) {
   const { user } = useAuthData()
   const [services, setServices] = useState<{ id: string; label: string }[]>(initial?.services || [])
   const [images, setImages] = useState<GalleryItem[]>((initial?.images || []).slice(0, 6))
+  const [linkBoxes, setLinkBoxes] = useState<{ id: string; title: string; url: string }[]>(initial?.linkBoxes || [])
   const [mainIdx, setMainIdx] = useState<number>(0)
   const [stats, setStats] = useState<{ memberCount: number; postCount: number; commentCount: number; classCount: number }>(
     (initial as any)?.stats || { memberCount: 0, postCount: 0, commentCount: 0, classCount: 0 }
@@ -93,6 +94,28 @@ export default function ClientCommunityPage({ initial }: { initial?: any }) {
       try { localStorage.setItem('rooted:return_to', `/${slug}`) } catch {}
     }
   }, [user, slug])
+
+  // 링크 박스 최신화: 초기 마운트 및 설정 변경 이벤트 수신 시 갱신
+  useEffect(() => {
+    let mounted = true
+    const refresh = async () => {
+      try {
+        const cid = community?.id
+        if (!cid) return
+        const lbs = await getCommunityLinkBoxes(cid)
+        if (!mounted) return
+        setLinkBoxes((lbs || []).map((v: any) => ({ id: v.id, title: v.title, url: v.url })))
+      } catch {}
+    }
+    void refresh()
+    const handler = (e: any) => {
+      const cid = e?.detail?.communityId
+      if (!cid || cid !== community?.id) return
+      void refresh()
+    }
+    try { window.addEventListener('community-linkboxes-changed', handler) } catch {}
+    return () => { mounted = false; try { window.removeEventListener('community-linkboxes-changed', handler) } catch {} }
+  }, [community?.id])
 
   // 데이터 로딩 함수 제거: initial이 없으면 커뮤니티 없음 UI를 표시
 
@@ -360,11 +383,11 @@ export default function ClientCommunityPage({ initial }: { initial?: any }) {
             <div>
               <Card className="hover:shadow-sm transition-all duration-300 border border-slate-300">
                 <CardHeader className="pb-2 sm:pb-3">
-                  <CardTitle className="flex items-center text-base sm:text-lg font-bold"><Gift className="w-4 h-4 sm:w-5 sm:h-5 mr-1 sm:mr-2 text-black" />커뮤니티 혜택</CardTitle>
+                  <CardTitle className="flex items-center text-base sm:text-base font-semibold"><Info className="w-4 h-4 sm:w-5 sm:h-5 mr-1 sm:mr-2 text-black" />상세 정보</CardTitle>
                 </CardHeader>
                 <CardContent className="space-y-2 sm:space-y-3 pt-0">
                   {services.length === 0 ? (
-                    <p className="text-sm sm:text-base text-slate-600">등록된 서비스가 아직 없습니다.</p>
+                    <p className="text-sm sm:text-base text-slate-600">현재 등록된 내용이 없습니다.</p>
                   ) : (
                     services.map((s, i) => (
                       <div key={s.id} className="flex items-center gap-2 sm:gap-3">
@@ -376,6 +399,22 @@ export default function ClientCommunityPage({ initial }: { initial?: any }) {
                 </CardContent>
               </Card>
             </div>
+
+            {/* 링크 박스: 항목이 있을 때만 개별 컨테이너 버튼으로 노출 */}
+            {Array.isArray(linkBoxes) && linkBoxes.length > 0 && linkBoxes.slice(0,10).map(lb => (
+              <div key={lb.id}>
+                <button
+                  onClick={() => { try { window.open(lb.url, '_blank', 'noopener'); } catch {} }}
+                  className="w-full text-left group"
+                  aria-label={`${lb.title}로 이동`}
+                >
+                  <div className="w-full border border-slate-300 rounded-2xl px-4 py-4 sm:px-5 sm:py-5 flex items-center justify-between bg-white shadow-sm hover:bg-slate-50 hover:shadow-md cursor-pointer transition-all">
+                    <span className="text-slate-900 text-sm sm:text-base font-medium truncate">{lb.title}</span>
+                    <ChevronRight className="w-4 h-4 text-slate-500 group-hover:text-slate-700 transition-colors" />
+                  </div>
+                </button>
+              </div>
+            ))}
           </div>
         </div>
       </main>

--- a/src/app/[slug]/classes/[id]/page.tsx
+++ b/src/app/[slug]/classes/[id]/page.tsx
@@ -12,6 +12,37 @@ import { Calendar, Eye, Users, ArrowLeft, CheckCircle2, Circle } from 'lucide-re
 import LiteYouTube from '@/components/LiteYouTube'
 
 export default function ClassDetailPage() {
+  // 텍스트 내 URL을 자동으로 링크로 변환
+  function linkify(text: string): (string | JSX.Element)[] {
+    const input = String(text || '')
+    const urlRegex = /((https?:\/\/|www\.)[^\s<]+)/gi
+    const nodes: (string | JSX.Element)[] = []
+    let lastIndex = 0
+    for (const match of input.matchAll(urlRegex)) {
+      const start = match.index ?? 0
+      if (start > lastIndex) nodes.push(input.slice(lastIndex, start))
+      let raw = match[0]
+      // 문장부호가 URL 끝에 붙은 경우 분리
+      const trailing = (raw.match(/[),.;!?]+$/) || [''])[0]
+      if (trailing) raw = raw.slice(0, -trailing.length)
+      const href = raw.startsWith('http') ? raw : `http://${raw}`
+      nodes.push(
+        <a
+          key={`link-${start}`}
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-blue-600 hover:underline underline-offset-2 break-all"
+        >
+          {raw}
+        </a>
+      )
+      if (trailing) nodes.push(trailing)
+      lastIndex = (match.index ?? 0) + (match[0]?.length || 0)
+    }
+    if (lastIndex < input.length) nodes.push(input.slice(lastIndex))
+    return nodes
+  }
   const { id, slug } = useParams<{ id: string; slug: string }>()
   const router = useRouter()
   const [item, setItem] = useState<any>(null)
@@ -224,7 +255,7 @@ export default function ClassDetailPage() {
           <h2 className="text-xl font-bold text-slate-900 mb-4">클래스 설명</h2>
           <div className="prose prose-slate max-w-none">
             <div className="whitespace-pre-wrap text-slate-700 leading-relaxed">
-              {item.description || '설명이 없습니다.'}
+              {linkify(item.description || '설명이 없습니다.')}
             </div>
           </div>
         </div>

--- a/src/app/[slug]/classes/[id]/page.tsx
+++ b/src/app/[slug]/classes/[id]/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useParams, useRouter } from 'next/navigation'
-import { useEffect, useState } from 'react'
+import { useEffect, useState, type ReactNode } from 'react'
 import { Button } from '@/components/ui/button'
 import { supabase } from '@/lib/supabase'
 import { getYouTubeEmbedUrl } from '@/lib/media'
@@ -13,10 +13,10 @@ import LiteYouTube from '@/components/LiteYouTube'
 
 export default function ClassDetailPage() {
   // 텍스트 내 URL을 자동으로 링크로 변환
-  function linkify(text: string): (string | JSX.Element)[] {
+  function linkify(text: string): ReactNode[] {
     const input = String(text || '')
     const urlRegex = /((https?:\/\/|www\.)[^\s<]+)/gi
-    const nodes: (string | JSX.Element)[] = []
+    const nodes: ReactNode[] = []
     let lastIndex = 0
     for (const match of input.matchAll(urlRegex)) {
       const start = match.index ?? 0

--- a/src/app/[slug]/settings/page.tsx
+++ b/src/app/[slug]/settings/page.tsx
@@ -110,7 +110,7 @@ export default function CommunitySettingsPage() {
                 <ChevronRight className="w-5 h-5" />
               </div>
             </div>
-            <p className="mt-1 text-xs text-slate-600 pl-7 text-left">커뮤니티 혜택 설정</p>
+            <p className="mt-1 text-xs text-slate-600 pl-7 text-left">커뮤니티 상세 내용, 링크 박스 설정</p>
           </button>
           <button
             onClick={() => setOpen('plan')}

--- a/src/app/api/community/detail/route.ts
+++ b/src/app/api/community/detail/route.ts
@@ -27,7 +27,7 @@ export async function GET(req: NextRequest) {
     }
 
     // 2) 나머지 의존 쿼리들을 병렬 실행 (프로필/서비스/이미지/멤버십/통계)
-    const [ownerProfileRes, servicesRes, imagesRows, membership, stats] = await Promise.all([
+    const [ownerProfileRes, servicesRes, imagesRows, membership, stats, linkBoxes] = await Promise.all([
       (async () => {
         try {
           const { data } = await supabase
@@ -101,6 +101,20 @@ export async function GET(req: NextRequest) {
           return { memberCount: 0 }
         }
       })(),
+      (async () => {
+        try {
+          const { data } = await supabase
+            .from('community_link_boxes')
+            .select('id,title,url,position,created_at')
+            .eq('community_id', (community as any).id)
+            .order('position', { ascending: true, nullsFirst: true })
+            .order('created_at', { ascending: true })
+            .limit(10)
+          return data || []
+        } catch {
+          return []
+        }
+      })(),
     ])
 
     let images = (imagesRows || []).map((r: any) => ({ key: r.key as string, url: buildPublicR2UrlForBucket(COMMUNITY_IMAGE_BUCKET, r.key as string), meta: { width: r.width || null, height: r.height || null, bytes: r.bytes || null, contentType: r.content_type || null } }))
@@ -123,6 +137,7 @@ export async function GET(req: NextRequest) {
       images,
       membership,
       stats,
+      linkBoxes,
     }
 
     return new Response(JSON.stringify(payload), {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -34,11 +34,13 @@ export default function HomePage() {
   const featuresRef = useRef<HTMLDivElement>(null)
   const [whoWhyVisible, setWhoWhyVisible] = useState(false)
   const whoWhyRef = useRef<HTMLDivElement>(null)
+  const [showSkeleton, setShowSkeleton] = useState(false)
 
   useEffect(() => {
     ;(async () => {
       try {
-        const res = await fetch('/api/featured', { cache: 'no-store' })
+        // 캐시 가능한 featured 먼저 시도 (메인 첫 진입 체감 로딩 최소화)
+        const res = await fetch('/api/featured')
         if (res.ok) {
           const featured = await res.json()
           if (Array.isArray(featured) && featured.length > 0) {
@@ -53,6 +55,15 @@ export default function HomePage() {
       }
     })()
   }, [])
+
+  // 스켈레톤은 250ms 이후에도 데이터가 없을 때만 노출 (첫 페인트 깜빡임 방지)
+  useEffect(() => {
+    if (communities.length > 0) { setShowSkeleton(false); return }
+    const t = setTimeout(() => {
+      if (communities.length === 0) setShowSkeleton(true)
+    }, 250)
+    return () => clearTimeout(t)
+  }, [communities.length])
 
   // 커뮤니티별 대표 이미지 매핑 간소화 (서버 제공 thumb_url 우선)
   useEffect(() => {
@@ -387,7 +398,15 @@ export default function HomePage() {
                           {(() => {
                             const topUrl = bannerMap[c.slug] || (c as any)?.thumb_url || getVersionedUrl((c as any)?.image_url, (c as any)?.updated_at)
                             return topUrl ? (
-                              <Image src={topUrl} alt="banner" fill className="object-cover" sizes="350px" priority={index < 2} />
+                              <Image
+                                src={topUrl}
+                                alt="banner"
+                                fill
+                                className="object-cover"
+                                sizes="350px"
+                                priority={index < 4}
+                                fetchPriority={index < 4 ? 'high' as any : 'auto' as any}
+                              />
                             ) : (
                               <div className="w-full h-full bg-gradient-to-b from-slate-100 to-slate-200" />
                             )
@@ -418,7 +437,7 @@ export default function HomePage() {
                         </div>
                       </Card>
                     ))
-                  ) : (
+                  ) : showSkeleton ? (
                     Array.from({ length: 6 }).map((_, idx) => (
                       <div key={`skeleton-${idx}`} className="w-[350px] flex-shrink-0 border border-slate-200 bg-white rounded-xl overflow-hidden">
                         <div className="w-full h-50 bg-slate-100 animate-pulse" />
@@ -434,7 +453,7 @@ export default function HomePage() {
                         </div>
                       </div>
                     ))
-                  )}
+                  ) : null}
                 </div>
                 
                 {/* 그라데이션 fade 효과 */}

--- a/src/components/community-dashboard/HomeTab.tsx
+++ b/src/components/community-dashboard/HomeTab.tsx
@@ -26,25 +26,21 @@ interface HomeTabProps { communityId: string; slug?: string; ownerId?: string | 
 
 export function HomeTab({ communityId, slug, ownerId, initial }: HomeTabProps) {
   const router = useRouter()
-  const [settings, setSettings] = useState<CommunitySettings | null>(null)
-  const [notices, setNotices] = useState<Notice[]>([])
-  // const [posts, setPosts] = useState<Post[]>([])
-  const [loading, setLoading] = useState<boolean>(true)
-  const [canManage, setCanManage] = useState<boolean>(false)
-  const [upcomingEvents, setUpcomingEvents] = useState<{ id: string; title: string; start_at: string; end_at?: string | null; location?: string | null; description?: string | null }[]>([])
-  const [recentActivity, setRecentActivity] = useState<{ id: string; kind: 'feed'|'blog'|'note'|'event'|'class'; title: string; created_at: string; href?: string; meta?: string }[]>([])
+  // 첫 렌더에서 서버 초기 데이터를 바로 반영하여 스켈레톤 깜빡임을 줄임
+  const [settings, setSettings] = useState<CommunitySettings | null>((initial?.settings || null) as any)
+  const [notices, setNotices] = useState<Notice[]>(((initial?.notices || []) as any))
+  const [loading, setLoading] = useState<boolean>(!(initial && (initial.settings || initial.notices || initial.upcomingEvents || initial.recentActivity)))
+  const [canManage, setCanManage] = useState<boolean>(!!initial?.canManage)
+  const [upcomingEvents, setUpcomingEvents] = useState<{ id: string; title: string; start_at: string; end_at?: string | null; location?: string | null; description?: string | null }[]>(((initial?.upcomingEvents || []) as any))
+  const [recentActivity, setRecentActivity] = useState<{ id: string; kind: 'feed'|'blog'|'note'|'event'|'class'; title: string; created_at: string; href?: string; meta?: string }[]>(((initial?.recentActivity || []) as any))
   // 홈 탭 내 통계 섹션은 별도 페이지로 이동됨
   const { brandColor: contextBrandColor } = useCommunityContext()
   const { user } = useAuthData()
   const isOwner = !!user && !!ownerId && user.id === ownerId
 
   useEffect(() => {
-    if (initial && (initial.settings || initial.notices)) {
-      setSettings((initial.settings || null) as any)
-      setNotices((initial.notices || []) as any)
-      setCanManage(!!initial.canManage)
-      setUpcomingEvents(((initial.upcomingEvents || []) as any).slice(0,5))
-      setRecentActivity((initial.recentActivity || []) as any)
+    // 초기 데이터가 이미 주어졌다면 추가 로딩 없이 종료
+    if (initial && (initial.settings || initial.notices || initial.upcomingEvents || initial.recentActivity)) {
       setLoading(false)
       try { window.dispatchEvent(new Event('dashboard-initial-ready')) } catch {}
       return
@@ -58,7 +54,7 @@ export function HomeTab({ communityId, slug, ownerId, initial }: HomeTabProps) {
         setSettings(home.settings)
         setNotices(home.notices)
         setCanManage(!!home.canManage)
-        setUpcomingEvents((home.upcomingEvents || []) as any)
+        setUpcomingEvents(((home.upcomingEvents || []) as any))
         setRecentActivity((home.recentActivity || []) as any)
       } finally {
         if (isMounted) setLoading(false)

--- a/src/components/community-dashboard/SettingsTab.tsx
+++ b/src/components/community-dashboard/SettingsTab.tsx
@@ -9,7 +9,7 @@ import { Textarea } from "@/components/ui/textarea"
 import { Label } from "@/components/ui/label"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { toast } from "sonner"
-import { getCommunitySettings, upsertCommunitySettings, getCommunityServices, addCommunityService, removeCommunityService, updateCommunity, deleteCommunity } from "@/lib/communities"
+import { getCommunitySettings, upsertCommunitySettings, getCommunityServices, addCommunityService, removeCommunityService, updateCommunity, deleteCommunity, getCommunityLinkBoxes, createCommunityLinkBox, updateCommunityLinkBox, deleteCommunityLinkBox } from "@/lib/communities"
 import { getAuthToken } from "@/lib/supabase"
 import { supabase } from "@/lib/supabase"
 import type { CommunitySettings } from "@/types/community"
@@ -43,6 +43,9 @@ export function SettingsTab({ communityId, mode }: SettingsTabProps) {
   // 공지사항 기능 제거됨
   const [services, setServices] = useState<{ id: string; label: string }[]>([])
   const [newService, setNewService] = useState("")
+  const [linkBoxes, setLinkBoxes] = useState<{ id: string; title: string; url: string }[]>([])
+  const [newLinkTitle, setNewLinkTitle] = useState<string>("")
+  const [newLinkUrl, setNewLinkUrl] = useState<string>("")
   const [slug, setSlug] = useState<string>(routeSlug || "")
   const [images, setImages] = useState<GalleryItem[]>([])
   const [uploading, setUploading] = useState<boolean>(false)
@@ -93,6 +96,10 @@ export function SettingsTab({ communityId, mode }: SettingsTabProps) {
         setSettingsInitial({ mission: (s?.mission || ""), brand_color: (s?.brand_color ?? null) as any })
         setPlan(data?.plan || null)
         setServices((data?.services || []).map((v: any) => ({ id: v.id, label: v.label })))
+        try {
+          const lb = await getCommunityLinkBoxes(communityId)
+          if (isMounted) setLinkBoxes((lb || []).map(v => ({ id: (v as any).id, title: (v as any).title, url: (v as any).url })))
+        } catch {}
         // basics: overview 응답의 basics를 활용해 초기화하여 추가 질의 축소
         const b = data?.basics
         if (b) {
@@ -109,14 +116,16 @@ export function SettingsTab({ communityId, mode }: SettingsTabProps) {
       } catch {
         // 폴백: 기존 개별 호출 (오류 시에도 UI는 로딩 해제)
         try {
-          const [s, sv] = await Promise.all([
+          const [s, sv, lb] = await Promise.all([
             getCommunitySettings(communityId),
             getCommunityServices(communityId),
+            getCommunityLinkBoxes(communityId),
           ])
           if (!isMounted) return
           setValues(s || {})
           setSettingsInitial({ mission: (s?.mission || ""), brand_color: (s?.brand_color ?? null) as any })
           setServices(sv.map(v => ({ id: v.id, label: v.label })))
+          setLinkBoxes((lb || []).map(v => ({ id: (v as any).id, title: (v as any).title, url: (v as any).url })))
         } catch {}
       } finally {
         if (isMounted) setLoading(false)
@@ -201,6 +210,31 @@ export function SettingsTab({ communityId, mode }: SettingsTabProps) {
     await removeCommunityService(id)
     setServices(prev => prev.filter(s => s.id !== id))
     toast.success('서비스가 삭제되었습니다')
+  }
+
+  // 링크 박스 핸들러
+  const handleAddLinkBox = async () => {
+    const title = newLinkTitle.trim().slice(0, 30)
+    const url = newLinkUrl.trim()
+    if (!title || !url) return
+    const created = await createCommunityLinkBox(communityId, title, url)
+    setLinkBoxes(prev => [...prev, { id: created.id, title: created.title, url: created.url }].slice(0, 10))
+    setNewLinkTitle("")
+    setNewLinkUrl("")
+    toast.success('링크가 추가되었습니다')
+    try { window.dispatchEvent(new CustomEvent('community-linkboxes-changed', { detail: { communityId } })) } catch {}
+  }
+  const handleUpdateLinkBox = async (id: string, patch: { title?: string; url?: string }) => {
+    const updated = await updateCommunityLinkBox(id, patch)
+    setLinkBoxes(prev => prev.map(lb => lb.id === id ? { id: id, title: updated.title, url: updated.url } : lb))
+    toast.success('링크가 저장되었습니다')
+    try { window.dispatchEvent(new CustomEvent('community-linkboxes-changed', { detail: { communityId } })) } catch {}
+  }
+  const handleDeleteLinkBox = async (id: string) => {
+    await deleteCommunityLinkBox(id)
+    setLinkBoxes(prev => prev.filter(lb => lb.id !== id))
+    toast.success('링크가 삭제되었습니다')
+    try { window.dispatchEvent(new CustomEvent('community-linkboxes-changed', { detail: { communityId } })) } catch {}
   }
 
   const onUpload = async (f: File, target: 'images' | 'icon' = 'images') => {
@@ -613,26 +647,71 @@ export function SettingsTab({ communityId, mode }: SettingsTabProps) {
   const ServicesCard = (
           <Card className="border-0 shadow-none sm:border sm:shadow-sm">
             <CardHeader className="flex items-center justify-between px-1 sm:px-4 py-3">
-              <CardTitle>커뮤니티 혜택</CardTitle>
+              <CardTitle>커뮤니티 상세 내용</CardTitle>
               <div className="flex gap-2">
-                <Button onClick={handleAddService} disabled={!newService.trim()}>추가</Button>
+                <Button onClick={handleAddService} disabled={!newService.trim()} className="cursor-pointer">추가</Button>
               </div>
             </CardHeader>
             <CardContent className="space-y-2.5 px-1 sm:px-4 pb-4">
               <div className="flex gap-2">
-                <Input value={newService} onChange={(e) => setNewService(e.target.value)} placeholder="커뮤니티에서 제공하는 가치를 입력하세요" />
+                <Input value={newService} onChange={(e) => setNewService(e.target.value)} placeholder="커뮤니티의 상세 내용을 추가해보세요" />
               </div>
               {services.length === 0 ? (
-                <p className="text-sm text-slate-600">등록된 서비스가 없습니다.</p>
+                <p className="text-sm text-slate-600">등록된 내용이 없습니다.</p>
               ) : (
                 <ul className="space-y-2 text-sm text-slate-800">
                   {services.map((s) => (
                     <li key={s.id} className="flex items-center justify-between border border-slate-200 rounded-md px-3 py-2">
                       <span>{s.label}</span>
-                      <Button size="sm" variant="outline" onClick={() => handleRemoveService(s.id)}>삭제</Button>
+                      <Button size="sm" variant="outline" onClick={() => handleRemoveService(s.id)} className="cursor-pointer">삭제</Button>
                     </li>
                   ))}
                 </ul>
+              )}
+            </CardContent>
+          </Card>
+  )
+
+  // 렌더링 유틸: 링크 박스 관리
+  const LinkBoxesCard = (
+          <Card className="border-0 shadow-none sm:border sm:shadow-sm">
+            <CardHeader className="flex items-center justify-between px-1 sm:px-4 py-3">
+              <CardTitle>링크 박스 관리 (최대 10개)</CardTitle>
+              <div className="flex gap-2">
+                <Button onClick={handleAddLinkBox} disabled={!newLinkTitle.trim() || !newLinkUrl.trim() || newLinkTitle.trim().length > 30 || linkBoxes.length >= 10} className="cursor-pointer">추가</Button>
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-3 px-1 sm:px-4 pb-4">
+              <div className="grid grid-cols-1 sm:grid-cols-[1fr_2fr] gap-2">
+                <Input value={newLinkTitle} maxLength={30} onChange={(e) => setNewLinkTitle(e.target.value)} placeholder="제목 (30자 이내)" />
+                <Input value={newLinkUrl} onChange={(e) => setNewLinkUrl(e.target.value)} placeholder="링크 (https:// 포함)" />
+              </div>
+              {linkBoxes.length === 0 ? (
+                <p className="text-sm text-slate-600">등록된 링크가 없습니다.</p>
+              ) : (
+                <ul className="space-y-2">
+                  {linkBoxes.map(lb => (
+                    <li key={lb.id} className="grid grid-cols-1 sm:grid-cols-[1fr_2fr_auto] gap-2 items-center border border-slate-200 rounded-md px-3 py-2">
+                      <Input
+                        value={lb.title}
+                        maxLength={30}
+                        onChange={(e)=> setLinkBoxes(prev => prev.map(x => x.id === lb.id ? { ...x, title: e.target.value } : x))}
+                        onBlur={(e)=> handleUpdateLinkBox(lb.id, { title: e.target.value })}
+                        placeholder="제목"
+                      />
+                      <Input
+                        value={lb.url}
+                        onChange={(e)=> setLinkBoxes(prev => prev.map(x => x.id === lb.id ? { ...x, url: e.target.value } : x))}
+                        onBlur={(e)=> handleUpdateLinkBox(lb.id, { url: e.target.value })}
+                        placeholder="링크"
+                      />
+                      <Button size="sm" variant="outline" onClick={() => handleDeleteLinkBox(lb.id)} className="cursor-pointer">삭제</Button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+              {linkBoxes.length >= 10 && (
+                <p className="text-xs text-slate-500">최대 10개까지 추가할 수 있습니다.</p>
               )}
             </CardContent>
           </Card>
@@ -814,6 +893,7 @@ export function SettingsTab({ communityId, mode }: SettingsTabProps) {
           {BannerCard}
           {ImagesCard}
           {ServicesCard}
+          {LinkBoxesCard}
         </div>
       )}
 
@@ -881,7 +961,7 @@ export function SettingsTab({ communityId, mode }: SettingsTabProps) {
         <div className="space-y-3">
           {mode === 'basic' && (<>{BasicInfoCard}</>)}
           {mode === 'images' && (<>{IconCard}{BannerCard}{ImagesCard}</>)}
-          {mode === 'details' && (<>{ServicesCard}</>)}
+          {mode === 'details' && (<>{ServicesCard}{LinkBoxesCard}</>)}
           {mode === 'plan' && (<>{PlanCard}</>)}
           {mode === 'advanced' && (<>{AdvancedCards}</>)}
         </div>

--- a/src/components/community-dashboard/pages/CalendarPage.tsx
+++ b/src/components/community-dashboard/pages/CalendarPage.tsx
@@ -49,10 +49,21 @@ export default function CalendarPage({ communityId }: { communityId: string }) {
   const [detail, setDetail] = useState<CalendarEvent | null>(null)
   const [isOwner, setIsOwner] = useState<boolean>(false)
   const [brandColor, setBrandColor] = useState<string | null>(null)
+  const [expandToday, setExpandToday] = useState<boolean>(false)
+  const [expandUpcoming, setExpandUpcoming] = useState<boolean>(false)
+  const [expandPast, setExpandPast] = useState<boolean>(false)
 
   const todayStr = new Date().toISOString().slice(0,10)
-  const todayEvents = useMemo(() => events.filter(e => e.start_at.slice(0,10) === todayStr), [events, todayStr])
+  const todayEvents = useMemo(() => {
+    return events.filter(e => {
+      const s = e.start_at.slice(0,10)
+      const t = e.end_at.slice(0,10)
+      // 오늘 날짜가 이벤트 시작~종료 범위에 포함되면 Today로 표시 (종료일 포함)
+      return s <= todayStr && t >= todayStr
+    })
+  }, [events, todayStr])
   const upcoming = useMemo(() => events.filter(e => e.start_at.slice(0,10) > todayStr).sort((a,b)=> a.start_at.localeCompare(b.start_at)).slice(0,5), [events, todayStr])
+  const past = useMemo(() => events.filter(e => e.end_at.slice(0,10) < todayStr).sort((a,b)=> b.end_at.localeCompare(a.end_at)).slice(0,5), [events, todayStr])
 
   const queryClient = useQueryClient()
   const { data: calData, isFetching: loadingOverview } = useQuery({
@@ -400,7 +411,7 @@ export default function CalendarPage({ communityId }: { communityId: string }) {
 
         {/* 사이드바 */}
         <div className="space-y-6 mt-6 md:mt-0">
-          {/* Today 섹션 */}
+          {/* 오늘의 일정 섹션 */}
           <div className="bg-white/80 backdrop-blur-sm rounded-3xl border border-slate-200/50 shadow-sm overflow-hidden">
             <div className="bg-gradient-to-r from-emerald-50 to-teal-50 border-b border-slate-200/50 p-6">
               <div className="flex items-center gap-3">
@@ -408,7 +419,7 @@ export default function CalendarPage({ communityId }: { communityId: string }) {
                   <ListChecks className="w-5 h-5 text-white"/>
                 </div>
                 <h3 className="text-lg font-bold bg-gradient-to-r from-emerald-700 to-teal-600 bg-clip-text text-transparent">
-                  Today
+                  오늘의 일정
                 </h3>
               </div>
             </div>
@@ -422,7 +433,7 @@ export default function CalendarPage({ communityId }: { communityId: string }) {
                 </div>
               ) : (
                 <div className="space-y-3">
-                      {todayEvents.map(ev => (
+                      {(expandToday ? todayEvents : todayEvents.slice(0,3)).map(ev => (
                     <div 
                       key={ev.id} 
                       className="group bg-gradient-to-r from-white to-slate-50 border border-slate-200/50 rounded-2xl p-4 cursor-pointer hover:shadow-lg hover:scale-[1.02] transition-all duration-200"
@@ -447,12 +458,24 @@ export default function CalendarPage({ communityId }: { communityId: string }) {
                       )}
                     </div>
                   ))}
+                  {todayEvents.length > 3 && (
+                    <div className="pt-1">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="w-full cursor-pointer rounded-xl"
+                        onClick={() => setExpandToday(v => !v)}
+                      >
+                        {expandToday ? '접기' : '더 보기'}
+                      </Button>
+                    </div>
+                  )}
                 </div>
               )}
             </div>
           </div>
 
-          {/* Upcoming 섹션 */}
+          {/* 다가오는 일정 섹션 */}
           <div className="bg-white/80 backdrop-blur-sm rounded-3xl border border-slate-200/50 shadow-sm overflow-hidden">
             <div className="bg-gradient-to-r from-indigo-50 to-purple-50 border-b border-slate-200/50 p-6">
               <div className="flex items-center gap-3">
@@ -460,7 +483,7 @@ export default function CalendarPage({ communityId }: { communityId: string }) {
                   <Clock className="w-5 h-5 text-white"/>
                 </div>
                 <h3 className="text-lg font-bold bg-gradient-to-r from-indigo-700 to-purple-600 bg-clip-text text-transparent">
-                  Upcoming
+                  다가오는 일정
                 </h3>
               </div>
             </div>
@@ -474,7 +497,7 @@ export default function CalendarPage({ communityId }: { communityId: string }) {
                 </div>
               ) : (
                 <div className="space-y-3">
-                      {upcoming.map(ev => (
+                      {(expandUpcoming ? upcoming : upcoming.slice(0,3)).map(ev => (
                     <div 
                       key={ev.id} 
                       className="group bg-gradient-to-r from-white to-slate-50 border border-slate-200/50 rounded-2xl p-4 cursor-pointer hover:shadow-lg hover:scale-[1.02] transition-all duration-200"
@@ -500,6 +523,77 @@ export default function CalendarPage({ communityId }: { communityId: string }) {
                       )}
                     </div>
                   ))}
+                  {upcoming.length > 3 && (
+                    <div className="pt-1">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="w-full cursor-pointer rounded-xl"
+                        onClick={() => setExpandUpcoming(v => !v)}
+                      >
+                        {expandUpcoming ? '접기' : '더 보기'}
+                      </Button>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* 지난 일정 섹션 */}
+          <div className="bg-white/80 backdrop-blur-sm rounded-3xl border border-slate-200/50 shadow-sm overflow-hidden">
+            <div className="bg-gradient-to-r from-rose-50 to-orange-50 border-b border-slate-200/50 p-6">
+              <div className="flex items-center gap-3">
+                <div className="p-2 rounded-2xl bg-gradient-to-br from-rose-500 to-orange-500 shadow-lg">
+                  <CalendarIcon className="w-5 h-5 text-white"/>
+                </div>
+                <h3 className="text-lg font-bold bg-gradient-to-r from-rose-700 to-orange-600 bg-clip-text text-transparent">
+                  지난 일정
+                </h3>
+              </div>
+            </div>
+            <div className="p-6">
+              {past.length === 0 ? (
+                <div className="text-center py-8">
+                  <div className="w-16 h-16 rounded-full bg-slate-100 flex items-center justify-center mx-auto mb-3">
+                    <CalendarIcon className="w-8 h-8 text-slate-400"/>
+                  </div>
+                  <div className="text-sm text-slate-500">지난 일정이 없습니다.</div>
+                </div>
+              ) : (
+                <div className="space-y-3">
+                  {(expandPast ? past : past.slice(0,3)).map(ev => (
+                    <div 
+                      key={ev.id} 
+                      className="group bg-gradient-to-r from-white to-slate-50 border border-slate-200/50 rounded-2xl p-4 cursor-pointer hover:shadow-lg hover:scale-[1.02] transition-all duration-200"
+                      onClick={()=>setDetail(ev)}
+                    >
+                      <div className="flex items-center gap-3 mb-2">
+                        <span className="w-3 h-3 rounded-full shadow-sm" style={{ backgroundColor: ev.color }} />
+                        <div className="text-sm font-semibold text-slate-800 group-hover:text-rose-700 transition-colors">
+                          {new Date(ev.start_at).toLocaleDateString('ko-KR', { month: 'short', day: 'numeric' })} · {ev.title}
+                        </div>
+                      </div>
+                      <div className="text-xs text-slate-500 flex items-center gap-1.5">
+                        <Clock className="w-3 h-3"/>
+                        {new Date(ev.start_at).toLocaleString('ko-KR', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
+                        <span className="mx-1">~</span>
+                        {new Date(ev.end_at).toLocaleString('ko-KR', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
+                      </div>
+                    </div>
+                  ))}
+                  {past.length > 3 && (
+                    <div className="pt-1">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="w-full cursor-pointer rounded-xl"
+                        onClick={() => setExpandPast(v => !v)}
+                      >
+                        {expandPast ? '접기' : '더 보기'}
+                      </Button>
+                    </div>
+                  )}
                 </div>
               )}
             </div>

--- a/src/lib/communities.ts
+++ b/src/lib/communities.ts
@@ -5,5 +5,6 @@ export * from '@/lib/community/notice-settings'
 export * from '@/lib/community/likes-dashboard-members'
 export * from '@/lib/community/pages'
 export * from '@/lib/community/blog'
+export * from '@/lib/community/link-boxes'
 
 

--- a/src/lib/community/link-boxes.ts
+++ b/src/lib/community/link-boxes.ts
@@ -1,0 +1,74 @@
+import { supabase, getUserId } from '@/lib/supabase'
+import type { CommunityLinkBox } from '@/types/community'
+import { cache60 } from './cache'
+
+export async function getCommunityLinkBoxes(communityId: string): Promise<CommunityLinkBox[]> {
+  const key = `linkboxes:${communityId}`
+  const now = Date.now()
+  const cached = cache60.get(key)
+  if (cached && now - cached.ts < 300_000) return (cached.data as CommunityLinkBox[]) || []
+  try {
+    const { data, error } = await supabase
+      .from('community_link_boxes')
+      .select('*')
+      .eq('community_id', communityId)
+      .order('position', { ascending: true, nullsFirst: true })
+      .order('created_at', { ascending: true })
+      .limit(10)
+    if (error) throw error
+    const res = (data as CommunityLinkBox[]) || []
+    cache60.set(key, { ts: now, data: res })
+    return res
+  } catch {
+    return []
+  }
+}
+
+export async function createCommunityLinkBox(communityId: string, title: string, url: string): Promise<CommunityLinkBox> {
+  const uid = await getUserId()
+  if (!uid) throw new Error('로그인이 필요합니다.')
+  const trimmed = (title || '').trim().slice(0, 30)
+  if (!trimmed) throw new Error('제목을 입력하세요.')
+  if (!url?.trim()) throw new Error('링크를 입력하세요.')
+  const normalizedUrl = /^https?:\/\//i.test(url) ? url : `https://${url}`
+  const { data, error } = await supabase
+    .from('community_link_boxes')
+    .insert({ community_id: communityId, title: trimmed, url: normalizedUrl })
+    .select()
+    .single()
+  if (error) throw error
+  // invalidate cache
+  cache60.set(`linkboxes:${communityId}`, { ts: 0, data: [] })
+  return data as CommunityLinkBox
+}
+
+export async function updateCommunityLinkBox(id: string, updates: Partial<Pick<CommunityLinkBox, 'title' | 'url' | 'position'>>): Promise<CommunityLinkBox> {
+  const payload: any = { ...updates }
+  if (payload.title) payload.title = String(payload.title).trim().slice(0, 30)
+  if (payload.url) payload.url = /^https?:\/\//i.test(payload.url) ? payload.url : `https://${payload.url}`
+  const { data, error } = await supabase
+    .from('community_link_boxes')
+    .update(payload)
+    .eq('id', id)
+    .select()
+    .single()
+  if (error) throw error
+  // invalidate cache for this community
+  try { cache60.set(`linkboxes:${(data as any).community_id}`, { ts: 0, data: [] }) } catch {}
+  // cannot know communityId here to clear cache; rely on time-based cache
+  return data as CommunityLinkBox
+}
+
+export async function deleteCommunityLinkBox(id: string): Promise<boolean> {
+  const { data, error } = await supabase
+    .from('community_link_boxes')
+    .delete()
+    .eq('id', id)
+    .select('community_id')
+    .single()
+  if (error) throw error
+  try { cache60.set(`linkboxes:${(data as any).community_id}`, { ts: 0, data: [] }) } catch {}
+  return true
+}
+
+

--- a/src/types/community.ts
+++ b/src/types/community.ts
@@ -92,6 +92,15 @@ export interface CommunityService {
   created_at: string
 }
 
+export interface CommunityLinkBox {
+  id: string
+  community_id: string
+  title: string
+  url: string
+  position?: number | null
+  created_at: string
+}
+
 export interface PostLike {
   id: string
   post_id: string


### PR DESCRIPTION
클래스 설명 URL 자동 링크 처리
커뮤니티 상세페이지 링크 박스 + 설정(추가/수정/삭제, 최대 10개)
캘린더 섹션 3개 제한 + ‘더 보기/접기’ 토글
메인 홈 이미지 우선 로딩 및 스켈레톤 깜빡임 완화
대시보드 홈 초기 데이터 즉시 반영으로 스켈레톤 제거